### PR TITLE
Add overwrite flag; use importlib; add abs and rel model path

### DIFF
--- a/Workflow/Interface.py
+++ b/Workflow/Interface.py
@@ -3,14 +3,16 @@
 import os
 import yaml
 import argparse
+import importlib
 import networks.Models as ms
 import common.user
 
 
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(description="ML interface.")
-  parser.add_argument("--train", action="store_true", help="Whether to train the network.")
-  parser.add_argument("--predict", action="store_true", help="Whether to predict using the network.")
+  parser.add_argument("-t","--train", action="store_true", help="Whether to train the network.")
+  parser.add_argument("-o","--overwrite", action="store_true", help="Whether to overwrite the network if already exists.")
+  parser.add_argument("-p","--predict", action="store_true", help="Whether to predict using the network.")
   args = parser.parse_args()
   assert args.train or args.predict, "Please specify which mode to use for the interface: --train or --predict."
 
@@ -27,21 +29,27 @@ if __name__ == '__main__':
     m = ms.getModule(cfg[t]["module"])
     if "config" in cfg[t]:
       config_path = cfg[t]["config"]
-      exec('import %s as config_%s'%( config_path, t))
-      mm = m(eval('config_%s'%( t )))
+      #exec('import %s as config_%s'%( config_path, t))
+      config_ = importlib.import_module(config_path)
+      mm = m(config=config_)
     elif "hyper_param" in cfg[t]: # FIXME: this needs to be checked when dealing with algorithms without a config as the input
       mm = m(cfg[t]["hyper_param"])
     else:
       mm = m()
     print("Task {}: Module {} loaded.".format(t,cfg[t]["module"]))
-    model_directory = os.path.join( common.user.model_directory, t )
-    model_path = os.path.join(model_directory, cfg[t]["model"])
+    if len(cfg[t]["model_name_abs"])==0:
+      model_directory = os.path.join( common.user.model_directory, t )
+      model_path = os.path.join(model_directory, cfg[t]["model_name_rel"])
+    else:
+      model_directory = os.path.dirname( cfg[t]["model_name_abs"] )
+      model_path = cfg[t]["model_name_abs"]
     # Fit the model
     if args.train:
       print("Training...")
+      print("Will save model at {}".format(model_path))
       if not os.path.exists(model_directory):
         os.makedirs(model_directory)
-      if os.path.exists(model_path):
+      if os.path.exists(model_path) and not args.overwrite:
         raise Exception("Model path {} already exists!".format(model_path))
       mm.train(datasets, cfg[t]["selection"], small=True)
       mm.save(model_path)

--- a/Workflow/config.yaml
+++ b/Workflow/config.yaml
@@ -16,7 +16,8 @@ Classifier:
 
 ICP:
   module: "ICP"
-  model: "ICP_1203" # path of the trained ML model 
+  model_name_rel: "ICP_1203" # reletive path of the trained ML model 
+  model_name_abs: "" # absolute path of the trained ML model 
   input: "/path/to/input"
   output: "/path/to/output"
   config: "ML.configs.icp_quad_jes"
@@ -27,7 +28,8 @@ ICP:
 
 BPT:
   module: "BoostedParametricTree"
-  model: "/path/to/model" # path of the trained ML model 
+  model_name_rel: "model_name" # reletive path of the trained ML model 
+  model_name_abs: "" # absolute path of the trained ML model 
   input: "/path/to/input"
   output: "/path/to/output"
   hyper_param:
@@ -37,7 +39,8 @@ BPT:
 
 Uncert_TES:
   module: "TES"
-  model: "/path/to/model"
+  model_name_rel: "model_name" # reletive path of the trained ML model 
+  model_name_abs: "" # absolute path of the trained ML model 
   input: "/path/to/input"
   output: "/path/to/output"
   hyper_param:


### PR DESCRIPTION
Changes:
- An overwrite flag is added: one can specify `-o` or `--overwrite` when running `Interface.py` for training
- Absolute and relative model path is used in the `config.yaml` file: when `model_name_abs` is set to a non-empty string, the trained model will be saved to the absolute path and the prediction will load from the absolute path. If `model_name_abs` is an empty string, then the relative path `model_name_rel` will be used.
- Use `importlib` to import configs