### PR TITLE
fixes to unbinned cfgs & new cfgs

### DIFF
--- a/configs/plots/binned_2016.yaml
+++ b/configs/plots/binned_2016.yaml
@@ -48,6 +48,18 @@ likelihood:
                   type: icph
                   job: icph_TTLep_pow_2016_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: icph
                   job: icph_TTLep_pow_2016_CMS_res_j_0_2016
@@ -171,6 +183,18 @@ likelihood:
                   type: icph
                   job: icph_DrellYan_2016_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_DrellYan_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_DrellYan_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_DrellYan_2016_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: icph
                   job: icph_DrellYan_2016_CMS_res_j_0_2016
@@ -294,6 +318,18 @@ likelihood:
                   type: icph
                   job: icph_SingleTop_2016_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_SingleTop_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_SingleTop_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_SingleTop_2016_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: icph
                   job: icph_SingleTop_2016_CMS_res_j_0_2016
@@ -417,6 +453,18 @@ likelihood:
                   type: icph
                   job: icph_TTSemi_pow_2016_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_TTSemi_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_TTSemi_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_TTSemi_pow_2016_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: icph
                   job: icph_TTSemi_pow_2016_CMS_res_j_0_2016
@@ -653,6 +701,54 @@ jobs:
       - coords: [1.0, 1.0]
         loader: TTLep_pow_2016
         addweights: ["scale_ren2p0_fac2p0"]
+
+  - id: icph_TTLep_pow_2016_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_TTLep_pow_2016_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_TTLep_pow_2016_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
 
   - id: icph_TTLep_pow_2016_CMS_res_j_0_2016 
     type: icph
@@ -1101,6 +1197,54 @@ jobs:
         loader: DrellYan_2016
         addweights: ["scale_ren2p0_fac2p0"]
 
+  - id: icph_DrellYan_2016_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: DrellYan_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: DrellYan_2016
+        nominal: true
+      - coords: [1.0]
+        loader: DrellYan_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_DrellYan_2016_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: DrellYan_2016
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: DrellYan_2016
+        nominal: true
+      - coords: [1.0]
+        loader: DrellYan_2016
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_DrellYan_2016_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: DrellYan_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: DrellYan_2016
+        nominal: true
+      - coords: [1.0]
+        loader: DrellYan_2016
+        addweights: ["pdf_alphas_up"]
+
   - id: icph_DrellYan_2016_CMS_res_j_0_2016 
     type: icph
     region: SR_binned
@@ -1548,6 +1692,54 @@ jobs:
         loader: SingleTop_2016
         addweights: ["scale_ren2p0_fac2p0"]
 
+  - id: icph_SingleTop_2016_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: SingleTop_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: SingleTop_2016
+        nominal: true
+      - coords: [1.0]
+        loader: SingleTop_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_SingleTop_2016_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: SingleTop_2016
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: SingleTop_2016
+        nominal: true
+      - coords: [1.0]
+        loader: SingleTop_2016
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_SingleTop_2016_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: SingleTop_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: SingleTop_2016
+        nominal: true
+      - coords: [1.0]
+        loader: SingleTop_2016
+        addweights: ["pdf_alphas_up"]
+
   - id: icph_SingleTop_2016_CMS_res_j_0_2016 
     type: icph
     region: SR_binned
@@ -1994,6 +2186,54 @@ jobs:
       - coords: [1.0, 1.0]
         loader: TTSemi_pow_2016
         addweights: ["scale_ren2p0_fac2p0"]
+
+  - id: icph_TTSemi_pow_2016_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTSemi_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_TTSemi_pow_2016_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2016
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: TTSemi_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2016
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_TTSemi_pow_2016_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTSemi_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2016
+        addweights: ["pdf_alphas_up"]
 
   - id: icph_TTSemi_pow_2016_CMS_res_j_0_2016 
     type: icph

--- a/configs/plots/binned_2016APV.yaml
+++ b/configs/plots/binned_2016APV.yaml
@@ -48,6 +48,18 @@ likelihood:
                   type: icph
                   job: icph_TTLep_pow_2016APV_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: icph
                   job: icph_TTLep_pow_2016APV_CMS_res_j_0_2016APV
@@ -175,6 +187,18 @@ likelihood:
                   type: icph
                   job: icph_DrellYan_2016APV_CMS_res_j_0_2016APV
                   parameters: [nu_CMS_res_j_0]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_DrellYan_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_DrellYan_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_DrellYan_2016APV_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_1
                   type: icph
                   job: icph_DrellYan_2016APV_CMS_res_j_1_2016APV
@@ -294,6 +318,18 @@ likelihood:
                   type: icph
                   job: icph_SingleTop_2016APV_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_SingleTop_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_SingleTop_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_SingleTop_2016APV_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: icph
                   job: icph_SingleTop_2016APV_CMS_res_j_0_2016APV
@@ -417,6 +453,17 @@ likelihood:
                   type: icph
                   job: icph_TTSemi_pow_2016APV_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_TTSemi_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_TTSemi_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_TTSemi_pow_2016APV_alphaS
                 - id: CMS_res_j_0
                   type: icph
                   job: icph_TTSemi_pow_2016APV_CMS_res_j_0_2016APV
@@ -653,6 +700,54 @@ jobs:
       - coords: [1.0, 1.0]
         loader: TTLep_pow_2016APV
         addweights: ["scale_ren2p0_fac2p0"]
+
+  - id: icph_TTLep_pow_2016APV_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_TTLep_pow_2016APV_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_TTLep_pow_2016APV_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
 
   - id: icph_TTLep_pow_2016APV_CMS_res_j_0_2016APV 
     type: icph
@@ -1101,6 +1196,56 @@ jobs:
         loader: DrellYan_2016APV
         addweights: ["scale_ren2p0_fac2p0"]
 
+  - id: icph_DrellYan_2016APV_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: DrellYan_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: DrellYan_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: DrellYan_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_DrellYan_2016APV_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: DrellYan_2016APV
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: DrellYan_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: DrellYan_2016APV
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_DrellYan_2016APV_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: DrellYan_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: DrellYan_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: DrellYan_2016APV
+        addweights: ["pdf_alphas_up"]
+
+
+
   - id: icph_DrellYan_2016APV_CMS_res_j_0_2016APV 
     type: icph
     region: SR_binned
@@ -1548,6 +1693,54 @@ jobs:
         loader: SingleTop_2016APV
         addweights: ["scale_ren2p0_fac2p0"]
 
+  - id: icph_SingleTop_2016APV_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: SingleTop_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: SingleTop_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: SingleTop_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_SingleTop_2016APV_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: SingleTop_2016APV
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: SingleTop_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: SingleTop_2016APV
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_SingleTop_2016APV_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: SingleTop_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: SingleTop_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: SingleTop_2016APV
+        addweights: ["pdf_alphas_up"]
+
   - id: icph_SingleTop_2016APV_CMS_res_j_0_2016APV 
     type: icph
     region: SR_binned
@@ -1994,6 +2187,54 @@ jobs:
       - coords: [1.0, 1.0]
         loader: TTSemi_pow_2016APV
         addweights: ["scale_ren2p0_fac2p0"]
+
+  - id: icph_TTSemi_pow_2016APV_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTSemi_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_TTSemi_pow_2016APV_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: TTSemi_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_TTSemi_pow_2016APV_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTSemi_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["pdf_alphas_up"]
 
   - id: icph_TTSemi_pow_2016APV_CMS_res_j_0_2016APV 
     type: icph

--- a/configs/plots/binned_2017.yaml
+++ b/configs/plots/binned_2017.yaml
@@ -48,6 +48,18 @@ likelihood:
                   type: icph
                   job: icph_TTLep_pow_2017_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: icph
                   job: icph_TTLep_pow_2017_CMS_res_j_0_2017
@@ -171,6 +183,18 @@ likelihood:
                   type: icph
                   job: icph_DrellYan_2017_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_DrellYan_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_DrellYan_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_DrellYan_2017_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: icph
                   job: icph_DrellYan_2017_CMS_res_j_0_2017
@@ -294,6 +318,18 @@ likelihood:
                   type: icph
                   job: icph_SingleTop_2017_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_SingleTop_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_SingleTop_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_SingleTop_2017_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: icph
                   job: icph_SingleTop_2017_CMS_res_j_0_2017
@@ -417,6 +453,18 @@ likelihood:
                   type: icph
                   job: icph_TTSemi_pow_2017_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_TTSemi_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_TTSemi_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_TTSemi_pow_2017_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: icph
                   job: icph_TTSemi_pow_2017_CMS_res_j_0_2017
@@ -653,6 +701,54 @@ jobs:
       - coords: [1.0, 1.0]
         loader: TTLep_pow_2017
         addweights: ["scale_ren2p0_fac2p0"]
+
+  - id: icph_TTLep_pow_2017_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_TTLep_pow_2017_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_TTLep_pow_2017_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
 
   - id: icph_TTLep_pow_2017_CMS_res_j_0_2017 
     type: icph
@@ -1101,6 +1197,54 @@ jobs:
         loader: DrellYan_2017
         addweights: ["scale_ren2p0_fac2p0"]
 
+  - id: icph_DrellYan_2017_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: DrellYan_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: DrellYan_2017
+        nominal: true
+      - coords: [1.0]
+        loader: DrellYan_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_DrellYan_2017_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: DrellYan_2017
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: DrellYan_2017
+        nominal: true
+      - coords: [1.0]
+        loader: DrellYan_2017
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_DrellYan_2017_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: DrellYan_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: DrellYan_2017
+        nominal: true
+      - coords: [1.0]
+        loader: DrellYan_2017
+        addweights: ["pdf_alphas_up"]
+
   - id: icph_DrellYan_2017_CMS_res_j_0_2017 
     type: icph
     region: SR_binned
@@ -1548,6 +1692,54 @@ jobs:
         loader: SingleTop_2017
         addweights: ["scale_ren2p0_fac2p0"]
 
+  - id: icph_SingleTop_2017_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: SingleTop_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: SingleTop_2017
+        nominal: true
+      - coords: [1.0]
+        loader: SingleTop_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_SingleTop_2017_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: SingleTop_2017
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: SingleTop_2017
+        nominal: true
+      - coords: [1.0]
+        loader: SingleTop_2017
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_SingleTop_2017_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: SingleTop_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: SingleTop_2017
+        nominal: true
+      - coords: [1.0]
+        loader: SingleTop_2017
+        addweights: ["pdf_alphas_up"]
+
   - id: icph_SingleTop_2017_CMS_res_j_0_2017 
     type: icph
     region: SR_binned
@@ -1994,6 +2186,54 @@ jobs:
       - coords: [1.0, 1.0]
         loader: TTSemi_pow_2017
         addweights: ["scale_ren2p0_fac2p0"]
+
+  - id: icph_TTSemi_pow_2017_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTSemi_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_TTSemi_pow_2017_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2017
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: TTSemi_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2017
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_TTSemi_pow_2017_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTSemi_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2017
+        addweights: ["pdf_alphas_up"]
 
   - id: icph_TTSemi_pow_2017_CMS_res_j_0_2017 
     type: icph

--- a/configs/plots/binned_2018.yaml
+++ b/configs/plots/binned_2018.yaml
@@ -48,6 +48,18 @@ likelihood:
                   type: icph
                   job: icph_TTLep_pow_2018_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: icph
                   job: icph_TTLep_pow_2018_CMS_res_j_0_2018
@@ -171,6 +183,18 @@ likelihood:
                   type: icph
                   job: icph_DrellYan_2018_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_DrellYan_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_DrellYan_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_DrellYan_2018_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: icph
                   job: icph_DrellYan_2018_CMS_res_j_0_2018
@@ -294,6 +318,18 @@ likelihood:
                   type: icph
                   job: icph_SingleTop_2018_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_SingleTop_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_SingleTop_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_SingleTop_2018_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: icph
                   job: icph_SingleTop_2018_CMS_res_j_0_2018
@@ -417,6 +453,18 @@ likelihood:
                   type: icph
                   job: icph_TTSemi_pow_2018_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: icph
+                  job: icph_TTSemi_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: icph
+                  job: icph_TTSemi_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: icph
+                  job: icph_TTSemi_pow_2018_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: icph
                   job: icph_TTSemi_pow_2018_CMS_res_j_0_2018
@@ -653,6 +701,54 @@ jobs:
       - coords: [1.0, 1.0]
         loader: TTLep_pow_2018
         addweights: ["scale_ren2p0_fac2p0"]
+
+  - id: icph_TTLep_pow_2018_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_TTLep_pow_2018_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_TTLep_pow_2018_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
 
   - id: icph_TTLep_pow_2018_CMS_res_j_0_2018 
     type: icph
@@ -1101,6 +1197,54 @@ jobs:
         loader: DrellYan_2018
         addweights: ["scale_ren2p0_fac2p0"]
 
+  - id: icph_DrellYan_2018_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: DrellYan_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: DrellYan_2018
+        nominal: true
+      - coords: [1.0]
+        loader: DrellYan_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_DrellYan_2018_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: DrellYan_2018
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: DrellYan_2018
+        nominal: true
+      - coords: [1.0]
+        loader: DrellYan_2018
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_DrellYan_2018_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: DrellYan_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: DrellYan_2018
+        nominal: true
+      - coords: [1.0]
+        loader: DrellYan_2018
+        addweights: ["pdf_alphas_up"]
+
   - id: icph_DrellYan_2018_CMS_res_j_0_2018 
     type: icph
     region: SR_binned
@@ -1548,6 +1692,54 @@ jobs:
         loader: SingleTop_2018
         addweights: ["scale_ren2p0_fac2p0"]
 
+  - id: icph_SingleTop_2018_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: SingleTop_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: SingleTop_2018
+        nominal: true
+      - coords: [1.0]
+        loader: SingleTop_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_SingleTop_2018_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: SingleTop_2018
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: SingleTop_2018
+        nominal: true
+      - coords: [1.0]
+        loader: SingleTop_2018
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_SingleTop_2018_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: SingleTop_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: SingleTop_2018
+        nominal: true
+      - coords: [1.0]
+        loader: SingleTop_2018
+        addweights: ["pdf_alphas_up"]
+
   - id: icph_SingleTop_2018_CMS_res_j_0_2018 
     type: icph
     region: SR_binned
@@ -1994,6 +2186,54 @@ jobs:
       - coords: [1.0, 1.0]
         loader: TTSemi_pow_2018
         addweights: ["scale_ren2p0_fac2p0"]
+
+  - id: icph_TTSemi_pow_2018_showerISR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTSemi_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+  - id: icph_TTSemi_pow_2018_showerFSR
+    type: icph
+    region: SR_binned
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2018
+        addweights: ["shower_isr1p0_fsr0p5"]
+      - coords: [0]
+        loader: TTSemi_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2018
+        addweights: ["shower_isr1p0_fsr2p0"]
+
+  - id: icph_TTSemi_pow_2018_alphaS
+    type: icph
+    region: SR_binned
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTSemi_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2018
+        addweights: ["pdf_alphas_up"]
 
   - id: icph_TTSemi_pow_2018_CMS_res_j_0_2018 
     type: icph

--- a/configs/unbinned/unbinned_2016.yaml
+++ b/configs/unbinned/unbinned_2016.yaml
@@ -151,7 +151,7 @@ jobs:
       pdf_n: [1, 2, 4, 5, 10, 12]
       pdf_type: PODBasis
     model:
-      n_trees: 1 #200
+      n_trees: 200
       learning_rate: 0.2
       loss: MSE                   # or "CrossEntropy"
       learn_global_score: true
@@ -190,7 +190,7 @@ jobs:
       filename: icp_TTLep_pow_2016_L1Prefire.pkl
   - id: pnn_TTLep_pow_2016_L1Prefire
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_l1prefire]
     combinations: [[nu_l1prefire]]
     base_points:
@@ -245,7 +245,7 @@ jobs:
       filename: icp_TTLep_pow_2016_PU.pkl
   - id: pnn_TTLep_pow_2016_PU
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_pu]
     combinations: [[nu_pu]]
     base_points:
@@ -301,7 +301,7 @@ jobs:
       filename: icp_TTLep_pow_2016_MuSF.pkl
   - id: pnn_TTLep_pow_2016_MuSF
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_MuSF]
     combinations: [[nu_MuSF]]
     base_points:
@@ -356,7 +356,7 @@ jobs:
       filename: icp_TTLep_pow_2016_EleSF.pkl
   - id: pnn_TTLep_pow_2016_EleSF
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_EleSF]
     combinations: [[nu_EleSF]]
     base_points:
@@ -410,7 +410,7 @@ jobs:
       filename: icp_TTLep_pow_2016_BTag_b.pkl
   - id: pnn_TTLep_pow_2016_BTag_b
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_btag_b]
     combinations: [[nu_btag_b]]
     base_points:
@@ -465,7 +465,7 @@ jobs:
       filename: icp_TTLep_pow_2016_BTag_l.pkl
   - id: pnn_TTLep_pow_2016_BTag_l
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_btag_l]
     combinations: [[nu_btag_l]]
     base_points:
@@ -539,7 +539,7 @@ jobs:
       filename: icp_TTLep_pow_2016_scales.pkl
   - id: pnn_TTLep_pow_2016_scales
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_mu_ren, nu_mu_fac]
     combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
           nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
@@ -609,7 +609,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
   - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_0]
     combinations: [[nu_CMS_res_j_0]]
     base_points:
@@ -657,7 +657,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
   - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_1]
     combinations: [[nu_CMS_res_j_1]]
     base_points:
@@ -705,7 +705,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
   - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_2]
     combinations: [[nu_CMS_res_j_2]]
     base_points:
@@ -753,7 +753,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
   - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_3]
     combinations: [[nu_CMS_res_j_3]]
     base_points:
@@ -801,7 +801,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
   - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_4]
     combinations: [[nu_CMS_res_j_4]]
     base_points:
@@ -849,7 +849,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
   - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_5]
     combinations: [[nu_CMS_res_j_5]]
     base_points:
@@ -898,7 +898,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom.pkl
   - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureBottom]
     combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
     base_points:
@@ -947,7 +947,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm.pkl
   - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureCharm]
     combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
     base_points:
@@ -995,7 +995,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon.pkl
   - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureGluon]
     combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
     base_points:
@@ -1043,7 +1043,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark.pkl
   - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureQuark]
     combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
     base_points:
@@ -1091,7 +1091,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016.pkl
   - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
     base_points:
@@ -1140,7 +1140,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute.pkl
   - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_Absolute]
     combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
     base_points:
@@ -1189,7 +1189,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016.pkl
   - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
     base_points:
@@ -1237,7 +1237,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1.pkl
   - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
     combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
     base_points:
@@ -1285,7 +1285,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016.pkl
   - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
     base_points:
@@ -1333,7 +1333,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2.pkl
   - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_EC2]
     combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
     base_points:
@@ -1381,7 +1381,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016.pkl
   - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
     base_points:
@@ -1429,7 +1429,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF.pkl
   - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_HF]
     combinations: [[nu_CMS_scale_j_Regrouped_HF]]
     base_points:
@@ -1477,7 +1477,7 @@ jobs:
       filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal.pkl
   - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
     combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
     base_points:
@@ -1526,7 +1526,7 @@ jobs:
         icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
   - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
     base_points:
@@ -1574,7 +1574,7 @@ jobs:
       filename: icp_TTLep_pow_2016_Uncl.pkl
   - id: pnn_TTLep_pow_2016_Uncl
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_Uncl]
     combinations: [[nu_Uncl]]
     base_points:

--- a/configs/unbinned/unbinned_2016APV.yaml
+++ b/configs/unbinned/unbinned_2016APV.yaml
@@ -55,6 +55,18 @@ likelihood:
                   type: pnn
                   job: pnn_TTLep_pow_2016APV_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: pnn
                   job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
@@ -151,7 +163,7 @@ jobs:
       pdf_n: [1, 2, 4, 5, 10, 12]
       pdf_type: PODBasis
     model:
-      n_trees: 1 #200
+      n_trees: 200
       learning_rate: 0.2
       loss: MSE                   # or "CrossEntropy"
       learn_global_score: true
@@ -190,7 +202,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
   - id: pnn_TTLep_pow_2016APV_L1Prefire
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_l1prefire]
     combinations: [[nu_l1prefire]]
     base_points:
@@ -245,7 +257,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_PU.pkl
   - id: pnn_TTLep_pow_2016APV_PU
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_pu]
     combinations: [[nu_pu]]
     base_points:
@@ -301,7 +313,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_MuSF.pkl
   - id: pnn_TTLep_pow_2016APV_MuSF
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_MuSF]
     combinations: [[nu_MuSF]]
     base_points:
@@ -356,7 +368,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_EleSF.pkl
   - id: pnn_TTLep_pow_2016APV_EleSF
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_EleSF]
     combinations: [[nu_EleSF]]
     base_points:
@@ -410,7 +422,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_BTag_b.pkl
   - id: pnn_TTLep_pow_2016APV_BTag_b
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_btag_b]
     combinations: [[nu_btag_b]]
     base_points:
@@ -465,7 +477,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_BTag_l.pkl
   - id: pnn_TTLep_pow_2016APV_BTag_l
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_btag_l]
     combinations: [[nu_btag_l]]
     base_points:
@@ -498,6 +510,7 @@ jobs:
     extras:
       use_scaler: scaler_TTLep_pow_2016APV
       use_icp: icp_TTLep_pow_2016APV_BTag_l
+
   - id: icp_TTLep_pow_2016APV_scales
     type: icp
     region: SR
@@ -537,9 +550,10 @@ jobs:
     train_ratio: true
     output:
       filename: icp_TTLep_pow_2016APV_scales.pkl
+
   - id: pnn_TTLep_pow_2016APV_scales
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_mu_ren, nu_mu_fac]
     combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
           nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
@@ -590,6 +604,169 @@ jobs:
     extras:
       use_scaler: scaler_TTLep_pow_2016APV
       use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTSemi_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTSemi_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      plot_every: 5
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTSemi_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTSemi_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      plot_every: 5
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTSemi_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTSemi_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTSemi_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      plot_every: 5
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_alphaS
+
   - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
     type: icp
     region: SR
@@ -607,9 +784,10 @@ jobs:
     train_ratio: true
     output:
       filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
   - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_0]
     combinations: [[nu_CMS_res_j_0]]
     base_points:
@@ -638,6 +816,7 @@ jobs:
     extras:
       use_scaler: scaler_TTLep_pow_2016APV
       use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
   - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
     type: icp
     region: SR
@@ -657,7 +836,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_1]
     combinations: [[nu_CMS_res_j_1]]
     base_points:
@@ -705,7 +884,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_2]
     combinations: [[nu_CMS_res_j_2]]
     base_points:
@@ -753,7 +932,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_3]
     combinations: [[nu_CMS_res_j_3]]
     base_points:
@@ -801,7 +980,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_4]
     combinations: [[nu_CMS_res_j_4]]
     base_points:
@@ -849,7 +1028,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_5]
     combinations: [[nu_CMS_res_j_5]]
     base_points:
@@ -898,7 +1077,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureBottom]
     combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
     base_points:
@@ -947,7 +1126,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureCharm]
     combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
     base_points:
@@ -995,7 +1174,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureGluon]
     combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
     base_points:
@@ -1043,7 +1222,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureQuark]
     combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
     base_points:
@@ -1091,7 +1270,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
     base_points:
@@ -1140,7 +1319,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_Absolute]
     combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
     base_points:
@@ -1189,7 +1368,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
     base_points:
@@ -1237,7 +1416,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
     combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
     base_points:
@@ -1285,7 +1464,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
     base_points:
@@ -1333,7 +1512,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_EC2]
     combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
     base_points:
@@ -1381,7 +1560,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
     base_points:
@@ -1429,7 +1608,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_HF]
     combinations: [[nu_CMS_scale_j_Regrouped_HF]]
     base_points:
@@ -1477,7 +1656,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
     combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
     base_points:
@@ -1526,7 +1705,7 @@ jobs:
         icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
     base_points:
@@ -1574,7 +1753,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_Uncl.pkl
   - id: pnn_TTLep_pow_2016APV_Uncl
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_Uncl]
     combinations: [[nu_Uncl]]
     base_points:

--- a/configs/unbinned/unbinned_2017.yaml
+++ b/configs/unbinned/unbinned_2017.yaml
@@ -151,7 +151,7 @@ jobs:
       pdf_n: [1, 2, 4, 5, 10, 12]
       pdf_type: PODBasis
     model:
-      n_trees: 1 #200
+      n_trees: 200
       learning_rate: 0.2
       loss: MSE                   # or "CrossEntropy"
       learn_global_score: true
@@ -190,7 +190,7 @@ jobs:
       filename: icp_TTLep_pow_2017_L1Prefire.pkl
   - id: pnn_TTLep_pow_2017_L1Prefire
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_l1prefire]
     combinations: [[nu_l1prefire]]
     base_points:
@@ -245,7 +245,7 @@ jobs:
       filename: icp_TTLep_pow_2017_PU.pkl
   - id: pnn_TTLep_pow_2017_PU
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_pu]
     combinations: [[nu_pu]]
     base_points:
@@ -301,7 +301,7 @@ jobs:
       filename: icp_TTLep_pow_2017_MuSF.pkl
   - id: pnn_TTLep_pow_2017_MuSF
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_MuSF]
     combinations: [[nu_MuSF]]
     base_points:
@@ -356,7 +356,7 @@ jobs:
       filename: icp_TTLep_pow_2017_EleSF.pkl
   - id: pnn_TTLep_pow_2017_EleSF
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_EleSF]
     combinations: [[nu_EleSF]]
     base_points:
@@ -410,7 +410,7 @@ jobs:
       filename: icp_TTLep_pow_2017_BTag_b.pkl
   - id: pnn_TTLep_pow_2017_BTag_b
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_btag_b]
     combinations: [[nu_btag_b]]
     base_points:
@@ -465,7 +465,7 @@ jobs:
       filename: icp_TTLep_pow_2017_BTag_l.pkl
   - id: pnn_TTLep_pow_2017_BTag_l
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_btag_l]
     combinations: [[nu_btag_l]]
     base_points:
@@ -539,7 +539,7 @@ jobs:
       filename: icp_TTLep_pow_2017_scales.pkl
   - id: pnn_TTLep_pow_2017_scales
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_mu_ren, nu_mu_fac]
     combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
           nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
@@ -609,7 +609,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
   - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_0]
     combinations: [[nu_CMS_res_j_0]]
     base_points:
@@ -657,7 +657,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
   - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_1]
     combinations: [[nu_CMS_res_j_1]]
     base_points:
@@ -705,7 +705,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
   - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_2]
     combinations: [[nu_CMS_res_j_2]]
     base_points:
@@ -753,7 +753,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
   - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_3]
     combinations: [[nu_CMS_res_j_3]]
     base_points:
@@ -801,7 +801,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
   - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_4]
     combinations: [[nu_CMS_res_j_4]]
     base_points:
@@ -849,7 +849,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
   - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_5]
     combinations: [[nu_CMS_res_j_5]]
     base_points:
@@ -898,7 +898,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom.pkl
   - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureBottom]
     combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
     base_points:
@@ -947,7 +947,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm.pkl
   - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureCharm]
     combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
     base_points:
@@ -995,7 +995,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon.pkl
   - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureGluon]
     combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
     base_points:
@@ -1043,7 +1043,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark.pkl
   - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureQuark]
     combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
     base_points:
@@ -1091,7 +1091,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2017.pkl
   - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2017
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_Absolute_2017]
     combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2017]]
     base_points:
@@ -1140,7 +1140,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute.pkl
   - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_Absolute]
     combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
     base_points:
@@ -1189,7 +1189,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2017.pkl
   - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2017
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2017]
     combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2017]]
     base_points:
@@ -1237,7 +1237,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1.pkl
   - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
     combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
     base_points:
@@ -1285,7 +1285,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2017.pkl
   - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2017
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_EC2_2017]
     combinations: [[nu_CMS_scale_j_Regrouped_EC2_2017]]
     base_points:
@@ -1333,7 +1333,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2.pkl
   - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_EC2]
     combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
     base_points:
@@ -1381,7 +1381,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2017.pkl
   - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2017
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_HF_2017]
     combinations: [[nu_CMS_scale_j_Regrouped_HF_2017]]
     base_points:
@@ -1429,7 +1429,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF.pkl
   - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_HF]
     combinations: [[nu_CMS_scale_j_Regrouped_HF]]
     base_points:
@@ -1477,7 +1477,7 @@ jobs:
       filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal.pkl
   - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
     combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
     base_points:
@@ -1526,7 +1526,7 @@ jobs:
         icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2017.pkl
   - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2017
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2017]
     combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2017]]
     base_points:
@@ -1574,7 +1574,7 @@ jobs:
       filename: icp_TTLep_pow_2017_Uncl.pkl
   - id: pnn_TTLep_pow_2017_Uncl
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_Uncl]
     combinations: [[nu_Uncl]]
     base_points:

--- a/configs/unbinned/unbinned_2018.yaml
+++ b/configs/unbinned/unbinned_2018.yaml
@@ -151,7 +151,7 @@ jobs:
       pdf_n: [1, 2, 4, 5, 10, 12]
       pdf_type: PODBasis
     model:
-      n_trees: 1 #200
+      n_trees: 200
       learning_rate: 0.2
       loss: MSE                   # or "CrossEntropy"
       learn_global_score: true
@@ -190,7 +190,7 @@ jobs:
       filename: icp_TTLep_pow_2018_L1Prefire.pkl
   - id: pnn_TTLep_pow_2018_L1Prefire
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_l1prefire]
     combinations: [[nu_l1prefire]]
     base_points:
@@ -245,7 +245,7 @@ jobs:
       filename: icp_TTLep_pow_2018_PU.pkl
   - id: pnn_TTLep_pow_2018_PU
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_pu]
     combinations: [[nu_pu]]
     base_points:
@@ -301,7 +301,7 @@ jobs:
       filename: icp_TTLep_pow_2018_MuSF.pkl
   - id: pnn_TTLep_pow_2018_MuSF
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_MuSF]
     combinations: [[nu_MuSF]]
     base_points:
@@ -356,7 +356,7 @@ jobs:
       filename: icp_TTLep_pow_2018_EleSF.pkl
   - id: pnn_TTLep_pow_2018_EleSF
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_EleSF]
     combinations: [[nu_EleSF]]
     base_points:
@@ -410,7 +410,7 @@ jobs:
       filename: icp_TTLep_pow_2018_BTag_b.pkl
   - id: pnn_TTLep_pow_2018_BTag_b
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_btag_b]
     combinations: [[nu_btag_b]]
     base_points:
@@ -465,7 +465,7 @@ jobs:
       filename: icp_TTLep_pow_2018_BTag_l.pkl
   - id: pnn_TTLep_pow_2018_BTag_l
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_btag_l]
     combinations: [[nu_btag_l]]
     base_points:
@@ -539,7 +539,7 @@ jobs:
       filename: icp_TTLep_pow_2018_scales.pkl
   - id: pnn_TTLep_pow_2018_scales
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_mu_ren, nu_mu_fac]
     combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
           nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
@@ -609,7 +609,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
   - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_0]
     combinations: [[nu_CMS_res_j_0]]
     base_points:
@@ -657,7 +657,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
   - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_1]
     combinations: [[nu_CMS_res_j_1]]
     base_points:
@@ -705,7 +705,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
   - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_2]
     combinations: [[nu_CMS_res_j_2]]
     base_points:
@@ -753,7 +753,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
   - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_3]
     combinations: [[nu_CMS_res_j_3]]
     base_points:
@@ -801,7 +801,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
   - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_4]
     combinations: [[nu_CMS_res_j_4]]
     base_points:
@@ -849,7 +849,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
   - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_res_j_5]
     combinations: [[nu_CMS_res_j_5]]
     base_points:
@@ -898,7 +898,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom.pkl
   - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureBottom]
     combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
     base_points:
@@ -947,7 +947,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm.pkl
   - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureCharm]
     combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
     base_points:
@@ -995,7 +995,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon.pkl
   - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureGluon]
     combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
     base_points:
@@ -1043,7 +1043,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark.pkl
   - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_FlavorPureQuark]
     combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
     base_points:
@@ -1091,7 +1091,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2018.pkl
   - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2018
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_Absolute_2018]
     combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2018]]
     base_points:
@@ -1140,7 +1140,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute.pkl
   - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_Absolute]
     combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
     base_points:
@@ -1189,7 +1189,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2018.pkl
   - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2018
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2018]
     combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2018]]
     base_points:
@@ -1237,7 +1237,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1.pkl
   - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
     combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
     base_points:
@@ -1285,7 +1285,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2018.pkl
   - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2018
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_EC2_2018]
     combinations: [[nu_CMS_scale_j_Regrouped_EC2_2018]]
     base_points:
@@ -1333,7 +1333,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2.pkl
   - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_EC2]
     combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
     base_points:
@@ -1381,7 +1381,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2018.pkl
   - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2018
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_HF_2018]
     combinations: [[nu_CMS_scale_j_Regrouped_HF_2018]]
     base_points:
@@ -1429,7 +1429,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF.pkl
   - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_HF]
     combinations: [[nu_CMS_scale_j_Regrouped_HF]]
     base_points:
@@ -1477,7 +1477,7 @@ jobs:
       filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal.pkl
   - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
     combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
     base_points:
@@ -1526,7 +1526,7 @@ jobs:
         icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2018.pkl
   - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2018
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2018]
     combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2018]]
     base_points:
@@ -1574,7 +1574,7 @@ jobs:
       filename: icp_TTLep_pow_2018_Uncl.pkl
   - id: pnn_TTLep_pow_2018_Uncl
     type: pnn
-    region: SR_binned
+    region: SR
     parameters: [nu_Uncl]
     combinations: [[nu_Uncl]]
     base_points:

--- a/plot/plot.py
+++ b/plot/plot.py
@@ -157,6 +157,9 @@ legend_columns = 3
 syst_groups = {
     'MODELING': [
         'Scales',
+        'ShowerISR', 
+        'ShowerFSR',
+        'AlphaS'
     ],
     'EXPERIMENTAL': [
         'L1Prefire',


### PR DESCRIPTION
This can be merged. I'm adding the shower and alphaS uncertainties to the plot configs and a first verision of ttbar-only unbinned configs with all systematics.

If you've made plots, it's just going to evaluate the missing systematics, everything else should be transparent.