### PR TITLE
Fix: PNN model and plot directories

### DIFF
--- a/ML/PNN/pnn_training.py
+++ b/ML/PNN/pnn_training.py
@@ -256,8 +256,12 @@ phaseout        = int(J.get("optim", {}).get("phaseout_epochs", 0))
 lr              = float(J.get("optim", {}).get("learning_rate", 1e-3))
 
 pnn = None
-model_dir = os.path.join(user.model_directory, cfg_base+"_for_debug" if args.for_debug else "", "PNN", J["id"])
-plot_dir  = os.path.join(user.plot_directory,  cfg_base+"_for_debug" if args.for_debug else "", "PNN", J["id"])
+
+cfg_path = cfg_base
+if args.for_debug:
+    cfg_base += "_for_debug"
+model_dir = os.path.join(user.model_directory, cfg_path, "PNN", J["id"])
+plot_dir  = os.path.join(user.plot_directory,  cfg_path, "PNN", J["id"])
 os.makedirs(model_dir, exist_ok=True); os.makedirs(plot_dir, exist_ok=True)
 
 if not args.overwrite:

--- a/ML/PNN/pnn_training_closure.py
+++ b/ML/PNN/pnn_training_closure.py
@@ -188,6 +188,10 @@ feat2col  = {f: i for i, f in enumerate(feat_names)}
 # ---------------- artifacts: scaler & ICP ----------------
 cfg_base = os.path.join(CFG.get("version", "default"), J["region"])
 
+cfg_path = cfg_base
+if args.for_debug:
+    cfg_base += "_for_debug"
+
 from ML.Scaler.Scaler import Scaler
 scaler_id = J["extras"].get("use_scaler", None)
 if scaler_id:
@@ -205,15 +209,15 @@ else:
 # ---------------- dirs ----------------
 model_dir = os.path.join(
     user.model_directory,
-    cfg_base + ("_for_debug" if args.for_debug else ""),
+    cfg_path,
     "PNN",
     J["id"],
 )
 
 plot_dir = os.path.join(
     user.plot_directory,
-    cfg_base + ("_for_debug" if args.for_debug else ""),
     "training_closure",
+    cfg_path,
     "PNN",
     J["id"],
 )


### PR DESCRIPTION
If not in debug mode, the PNN models and plots are stored in the top-level directory instead of their versioned directory. This PR fixes this.

Making a PR (instead of just commiting the small changes) so that people are aware, as we'll be having a PNN training round quite soon, and I didn't want people to not know where the trained models are.

