### PR TITLE
Rate/signal strength fits

### DIFF
--- a/configs/unbinned/unbinned_2016_rate.yaml
+++ b/configs/unbinned/unbinned_2016_rate.yaml
@@ -1,0 +1,1737 @@
+version: unbinned_2016_v2
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                type: norm
+                parameters: [mu]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+ 
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/fit/Likelihood.py
+++ b/fit/Likelihood.py
@@ -252,7 +252,7 @@ def build_hypothesis_from_likelihood(like_info, *, name=None,
     Includes parameters discovered in BOTH unbinned and binned sections.
 
     Heuristics:
-      - POIs are marked isPOI=True if name starts with 'c'.
+      - POIs have initial value of 1.0 if 'mu' in name
       - Nuisances are marked penalized unless penalize_nuisances=False.
     """
     pois = like_info.get('pois', []) or []
@@ -261,7 +261,8 @@ def build_hypothesis_from_likelihood(like_info, *, name=None,
     params = []
     for nm in pois:
         is_wc = nm.startswith('c')
-        params.append(ModelParameter(name=nm, val=poi_init, isPOI=True, isPenalized=False))
+        poi_init_val = 1.0 if 'mu' in nm else poi_init
+        params.append(ModelParameter(name=nm, val=poi_init_val, isPOI=True, isPenalized=False))
     for nm in nuis:
         params.append(ModelParameter(
             name=nm, val=nuis_init, isPOI=False,
@@ -529,6 +530,8 @@ class N2LL:
         # in-memory pointers
         self._poi_order: Dict[Tuple[str, str], List[str]] = {}         # (rid,cid) -> POI names order for R_A
         self._cache_paths: Dict[Tuple[str, str], Tuple[str, str]] = {} # (rid,cid) -> (h5_path, meta_path)
+        # check if poi is norm/BIT, avoiding string comparisons at runtime
+        self._poi_is_norm: Dict[Tuple[str, str], bool] = {}       # (rid, cid) -> is norm POI
 
         # opened runtime state (filled by prepare_runtime)
         self._h5: Dict[Tuple[str, str], "h5py.File"] = {}
@@ -574,10 +577,20 @@ class N2LL:
                 key = (rid, cid)
 
                 poi = C.get('POI', {}) or {}
-                poi_pred = poi.get('predictor', None)
+                # for now assuming the user will not have
+                # two types of POIs (BIT vs. norm)
+                poi_type = poi.get('type', None)
+                if poi_type == 'norm':
+                    print(f'[N2LL] Using signal strength for {rid}/{cid}')
+                    self._poi_is_norm[key] = True
+                elif poi_type == 'bit':
+                    poi_pred = poi.get('predictor', None)
+                    if poi_pred is None:
+                        raise RuntimeError(f"[N2LL] Missing BIT predictor for {rid}/{cid}")
+                    self._poi_is_norm[key] = False                    
+                else:
+                    raise RuntimeError(f"[N2LL] POI of type {poi_type} does not exist")
                 poi_names = list(poi.get('parameters', []) or [])
-                if poi_pred is None:
-                    raise RuntimeError(f"[N2LL] Missing BIT predictor for {rid}/{cid}")
                 if not poi_names:
                     raise RuntimeError(f"[N2LL] No POI parameter names for {rid}/{cid}")
                 self._poi_order[key] = poi_names
@@ -799,9 +812,13 @@ class N2LL:
                         self._append_1d(writer["w0"], w0)
                         self._append_1d(writer["g"],  G[:, p_index].astype(np.float64, copy=False))
 
+                        # default is POI of type BIT, alternative is type norm. if something else, crashes in _prepare_structure
+                        if self._poi_is_norm:
+                            R_A = np.ones((Nb,1))
+                        else:
                         # BIT R_A
-                        poi_pred = (C.get('POI') or {}).get('predictor')
-                        R_A = predict_bit_ratio(poi_pred, X[:, C['POI']['column_mask']])  # (Nb, nA)
+                            poi_pred = (C.get('POI') or {}).get('predictor')
+                            R_A = predict_bit_ratio(poi_pred, X[:, C['POI']['column_mask']])  # (Nb, nA)
 
                         if writer["R"] is None:
                             nA = R_A.shape[1]
@@ -1002,7 +1019,10 @@ class N2LL:
 
                 # R with POI A-basis headers
                 poi_names = self._poi_order[(rid, cid)]
-                A_names = _poi_A_names(poi_names)
+                if self._poi_is_norm[(rid, cid)]:
+                    A_names = poi_names
+                else:
+                    A_names = _poi_A_names(poi_names)
                 R_dset = f['R']
                 print(f"  - R  shape={R_dset.shape}")
                 print(f"    R columns (|A|={len(A_names)}): {A_names}")
@@ -1167,7 +1187,12 @@ class N2LL:
         c_vec = {p.name: float(p.val) for p in getattr(hypothesis, 'POIs', [])}
         for cid in self._class_ids_by_region.get(rid, []):
             poi_names = self._poi_order[(rid, cid)]
-            cA_per_class[cid] = expand_pois_linear_quadratic(poi_names, c_vec)
+            # key assumption: only one norm per class/region
+            # NB: this part still needs to be more tested
+            if self._poi_is_norm[(rid, cid)]:
+                cA_per_class[cid] = np.array([c_vec[poi_names[0]]], dtype=np.float64)
+            else:
+                cA_per_class[cid] = expand_pois_linear_quadratic(poi_names, c_vec)
         return cA_per_class
 
     def _assemble_nuA_groups(self, rid: str, hypothesis) -> Dict[str, list[tuple[dict, np.ndarray]]]:
@@ -1200,7 +1225,11 @@ class N2LL:
             R_slice = f['R'][start:stop, :]             # (M, nA)
             cA      = cA_per_class[cid]
             if R_slice.shape[1] != cA.shape[0]:
-                raise RuntimeError(f"[N2LL] BIT dim {R_slice.shape[1]} != |A| {cA.shape[0]} for {rid}/{cid}")
+                if self._poi_is_norm:
+                    error_msg = f"[N2LL] POI dim {R_slice.shape[1]} != |A| {cA.shape[0]} for {rid}/{cid}"
+                else:
+                    error_msg = f"[N2LL] BIT dim {R_slice.shape[1]} != |A| {cA.shape[0]} for {rid}/{cid}"
+                raise RuntimeError(error_msg)
             c_dot_R = R_slice @ cA                      # (M,)
 
             # build exponent from all Δ-groups


### PR DESCRIPTION
First version of unbinned rate fits seems to work.

Main issue: when scanning over the signal strength, Minuit starts at 1.0 as requested, but then starts going to large values, first positive, then negative. After the first evaluation with a large negative value, the POI is set to nan, and it is propagated to the likelihood evaluations. I wasn't really able to debug this yet.