### PR TITLE
Add fit configs for v3

### DIFF
--- a/configs/unbinned_v3/unbinned_2016.yaml
+++ b/configs/unbinned_v3/unbinned_2016.yaml
@@ -1,0 +1,1801 @@
+version: unbinned_2016_v3
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_pod_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+#  - id: bit_pod_TTLep_pow_2016
+#    type: bit
+#    region: SR
+#    process: TTLep_pow_2016
+#    selection: null               # optional extra selection layered on top
+#    numba: True
+#    pdf:
+#      pdf_n: [1, 2, 4, 5, 10, 12]
+#      pdf_type: PODBasis
+#      pdf_basis: 250503_pod_basis_40k
+#    model:
+#      n_trees: 200
+#      learning_rate: 0.2
+#      loss: MSE                   # or "CrossEntropy"
+#      learn_global_score: true
+#    runtime:
+#      training_plots: true        # keep if you want training plots
+#    output:
+#      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: true
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 32
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+ 
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v3/unbinned_2016APV.yaml
+++ b/configs/unbinned_v3/unbinned_2016APV.yaml
@@ -1,0 +1,1781 @@
+version: unbinned_2016APV_v3
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_pod_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v3/unbinned_2017.yaml
+++ b/configs/unbinned_v3/unbinned_2017.yaml
@@ -1,0 +1,1778 @@
+version: unbinned_2017_v3
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_pod_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2017
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2017]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2017
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2017]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2017
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2017]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2017
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2017]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2017
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2017]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2017
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2017]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2017]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2017
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2017]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2017]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2017
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2017
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2017]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2017]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2017
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2017]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2017]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2017
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2017
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2017]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2017]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2017
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2017]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2017]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2017
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2017
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2017]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2017]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2017
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2017]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2017]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2017
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2017
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2017]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2017]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2017_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2017
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2017]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2017]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2017
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v3/unbinned_2018.yaml
+++ b/configs/unbinned_v3/unbinned_2018.yaml
@@ -1,0 +1,1778 @@
+version: unbinned_2018_v3
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_pod_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                  #parameters: [nu_mu_ren, nu_mu_fac] #FIXME
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2018
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2018]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2018
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2018]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2018
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2018]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2018
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2018]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2018
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2018]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+      l1: 0.0
+      l2: 0.0001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2018
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2018]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2018
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2018]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2018
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2018
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2018]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2018
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2018]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2018
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2018
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2018]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2018
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2018]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2018
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2018
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2018]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2018
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2018]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2018
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2018
+    type: icp
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2018]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2018_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2018
+    type: pnn
+    region: SR
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2018]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2018
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/fit/Likelihood.py
+++ b/fit/Likelihood.py
@@ -2007,6 +2007,7 @@ if __name__ == "__main__":
     p.add_argument("--no_syst", action="store_true", help="Disable all nuisances (freeze to 0).")
     p.add_argument("--asimov", nargs="+", default=None,  metavar=("PAR", "VAL"), help="Set an off-nominal Asimov hypothesis via pairs: --asimov par1 val1 par2 val2 ...")
     p.add_argument("--shuffle", nargs="+", default=None,  help="Shuffle these features")
+    p.add_argument("--minos", action="store_true", default=False, help="Whether to use MINOS in the fit. If not set, then use HESSE by default.")
     args = p.parse_args()
 
     import common.yaml_loader as yaml_loader
@@ -2102,8 +2103,8 @@ if __name__ == "__main__":
             step=step,
             print_every=1,
             do_migrad=True,
-            do_hesse=True,
-            do_minos=False,
+            do_hesse=not args.minos,
+            do_minos=args.minos,
         )
 
         serialize_result(m, base, version, args, out_path)

--- a/plot/postfitsys/compare_correlations.py
+++ b/plot/postfitsys/compare_correlations.py
@@ -1,0 +1,165 @@
+"""Compare correlation matrices from two fit JSON files."""
+
+import argparse
+import json
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import common.user as user
+
+
+def load_correlation(json_path: str) -> tuple[list[str], np.ndarray]:
+    """Load correlation order and matrix from a fit JSON file."""
+    with open(json_path) as file_handle:
+        data = json.load(file_handle)
+
+    correlation = data.get("correlation", {})
+    order = correlation.get("order")
+    matrix = correlation.get("matrix")
+
+    if order is None or matrix is None:
+        raise ValueError(f"Missing correlation data in {json_path}")
+
+    correlation_matrix = np.array(matrix, dtype=float)
+    return order, correlation_matrix
+
+def create_comparison_canvas(
+    order: list[str],
+    matrix_a: np.ndarray,
+    matrix_b: np.ndarray,
+    output_dir: str,
+    label_a: str,
+    label_b: str,
+    diff_matrix: np.ndarray
+) -> None:
+    
+    """Create a single-canvas comparison plot for two correlation matrices and their difference."""
+    max_abs_diff = float(np.max(np.abs(diff_matrix)))
+    diff_range = max_abs_diff if max_abs_diff > 0 else 1.0
+
+    side = max(6.0, 0.25 * len(order))
+    fig, axes = plt.subplots(1, 3, figsize=(side * 3.0, side))
+
+    colormap = "coolwarm"
+
+    images = [
+        axes[0].imshow(matrix_a, vmin=-1.0, vmax=1.0, cmap=colormap),
+        axes[1].imshow(matrix_b, vmin=-1.0, vmax=1.0, cmap=colormap),
+        axes[2].imshow(diff_matrix, vmin=-diff_range, vmax=diff_range, cmap=colormap),
+    ]
+
+    titles = [label_a, label_b, "Correlation difference"]
+    for axis, title in zip(axes, titles):
+        axis.set_title(title)
+        axis.set_xticks(range(len(order)))
+        axis.set_yticks(range(len(order)))
+        axis.set_xticklabels(order, rotation=90, fontsize=6)
+        axis.set_yticklabels(order, fontsize=6)
+
+    for axis, image in zip(axes, images):
+        fig.colorbar(image, ax=axis, fraction=0.046, pad=0.04)
+
+    fig.tight_layout()
+
+    os.makedirs(output_dir, exist_ok=True)
+    fig.savefig(os.path.join(output_dir, "correlation_comparison.png"), dpi=150, bbox_inches="tight")
+    fig.savefig(os.path.join(output_dir, "correlation_comparison.pdf"), bbox_inches="tight")
+    plt.close(fig)
+
+
+def create_difference_heatmap(
+    order: list[str],
+    diff_matrix: np.ndarray,
+    output_dir: str,
+    label_a: str,
+    label_b: str
+) -> None:
+    """Create a standalone heatmap of the difference correlation matrix."""
+    max_abs_diff = float(np.max(np.abs(diff_matrix)))
+    diff_range = max_abs_diff if max_abs_diff > 0 else 1.0
+
+    side = max(6.0, 0.25 * len(order))
+    fig, ax = plt.subplots(figsize=(side, side))
+
+    image = ax.imshow(diff_matrix, vmin=-diff_range, vmax=diff_range, cmap="coolwarm")
+    ax.set_title("Correlation Difference")
+    ax.set_xticks(range(len(order)))
+    ax.set_yticks(range(len(order)))
+    ax.set_xticklabels(order, rotation=90, fontsize=6)
+    ax.set_yticklabels(order, fontsize=6)
+
+    fig.colorbar(image, ax=ax, fraction=0.046, pad=0.04)
+    fig.tight_layout()
+
+    os.makedirs(output_dir, exist_ok=True)
+    fig.savefig(os.path.join(output_dir, "correlation_difference.png"), dpi=150, bbox_inches="tight")
+    fig.savefig(os.path.join(output_dir, "correlation_difference.pdf"), bbox_inches="tight")
+    plt.close(fig)
+
+
+def main() -> None:
+    """Run the correlation comparison CLI."""
+    parser = argparse.ArgumentParser(
+        description="Compare correlation matrices across two JSON files"
+    )
+    parser.add_argument(
+        "fit_a",
+        help="Path to first fit JSON file"
+    )
+    parser.add_argument(
+        "fit_b",
+        help="Path to second fit JSON file"
+    )
+    parser.add_argument(
+        "-o", "--output",
+        help="Output directory (relative to user.plot_directory)",
+    )
+    args = parser.parse_args()
+
+    fit_a_path = args.fit_a
+    fit_b_path = args.fit_b
+
+    output_name = args.output
+    if output_name is None:
+        base_a = os.path.basename(fit_a_path).replace(".json", "")
+        base_b = os.path.basename(fit_b_path).replace(".json", "")
+        output_name = f"correlation_comparison_{base_a}_vs_{base_b}"
+
+    output_dir = os.path.join(user.plot_directory, output_name)
+
+    order_a, matrix_a = load_correlation(fit_a_path)
+    order_b, matrix_b = load_correlation(fit_b_path)
+
+    if order_a != order_b:
+        raise ValueError("Correlation orders differ; comparison aborted")
+
+    if matrix_a.shape != matrix_b.shape:
+        raise ValueError(
+            f"Matrix shapes differ: {matrix_a.shape} vs {matrix_b.shape}"
+        )
+
+    diff_matrix = matrix_a - matrix_b
+    base_a = os.path.basename(fit_a_path).replace(".json", "")
+    base_b = os.path.basename(fit_b_path).replace(".json", "")
+
+    create_comparison_canvas(order_a, matrix_a, matrix_b, output_dir, base_a, base_b, diff_matrix)
+    create_difference_heatmap(order_a, diff_matrix, output_dir, base_a, base_b)
+    
+    diff_filename = f"correlation_only_diff_{base_a}_vs_{base_b}.json"
+    os.makedirs(output_dir, exist_ok=True)
+    payload = {
+        "correlation": {
+            "order": order_a,
+            "matrix": diff_matrix.tolist()
+        }
+    }
+    with open(os.path.join(output_dir, diff_filename), "w") as file_handle:
+        json.dump(payload, file_handle, indent=2)    
+
+    print(f"Outputs saved to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plot/postfitsys/compare_fits.py
+++ b/plot/postfitsys/compare_fits.py
@@ -1,0 +1,134 @@
+import json
+import argparse
+import matplotlib.pyplot as plt
+import numpy as np
+from typing import List, Dict, Tuple
+import os
+
+import common.syncer as syncer
+import common.user as user
+
+
+def load_fit_results(json_path: str) -> Tuple[str, List[Dict]]:
+    """Load parameter values and errors from fit JSON file."""
+    with open(json_path) as f:
+        data = json.load(f)
+    
+    version = data['version']
+    param_order = data['free_parameter_order']
+    params_by_name = {p['name']: p for p in data['parameters']}
+    
+    ordered_params = [params_by_name[name] for name in param_order]
+    return version, ordered_params
+
+
+def create_comparison_plot(
+    fit_files: List[str],
+    output_dir: str,
+    blind_params: List[str] = None
+) -> None:
+    """Create comparison plot of fit parameters across multiple fits."""
+    
+    blind_params = blind_params or []
+    
+    fit_data = []
+    for fit_file in fit_files:
+        version, params = load_fit_results(fit_file)
+        fit_data.append((version, params))
+    
+    num_fits = len(fit_data)
+    param_names = [p['name'] for p in fit_data[0][1]]
+    num_params = len(param_names)
+    
+    fig, ax = plt.subplots(figsize=(12, max(10, num_params * 0.3)))
+    
+    y_positions = np.arange(num_params)
+    bar_height = 0.8 / num_fits
+    # from https://matplotlib.org/stable/gallery/color/color_sequences.html
+    colors = plt.color_sequences['tab10']
+    
+    for fit_idx, (version, params) in enumerate(fit_data):
+        values = []
+        errors = []
+        labels_display = []
+        
+        for param in params:
+            param_name = param['name']
+            
+            if param_name in blind_params:
+                values.append(0)
+                errors.append(0)
+                labels_display.append('x')
+            else:
+                values.append(param['value'])
+                errors.append(param['error'])
+                labels_display.append(f"{param['value']:.2f}")
+        
+        y_offset = y_positions + (num_fits - 1) * bar_height / 2 - fit_idx * bar_height
+        
+        bars = ax.barh(
+            y_offset,
+            values,
+            bar_height,
+            xerr=errors,
+            label=version,
+            color=colors[fit_idx],
+            ecolor=colors[fit_idx],
+            alpha=0.8,
+            capsize=3
+        )
+    
+    # Add horizontal lines between parameters
+    for i in range(num_params - 1):
+        ax.axhline(y=i + 0.5, color='gray', linestyle='--', linewidth=0.5, alpha=0.3)
+    
+    ax.set_yticks(y_positions)
+    ax.set_yticklabels(param_names, fontsize=9)
+    ax.set_xlabel('Parameter value', fontsize=11)
+    ax.legend(loc='upper right', fontsize=10)
+    ax.grid(axis='x', alpha=0.3)
+    ax.axvline(x=0, color='black', linestyle='--', linewidth=0.8, alpha=0.5)
+    
+    fig.tight_layout()
+    
+    os.makedirs(output_dir, exist_ok=True)
+    
+    fig.savefig(output_dir + '/fit_comparison.png', dpi=150, bbox_inches='tight')
+    fig.savefig(output_dir + '/fit_comparison.pdf', bbox_inches='tight')
+    plt.close(fig)
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Compare fit results across multiple JSON files'
+    )
+    parser.add_argument(
+        'fit_files',
+        nargs='+',
+        help='Path(s) to fit result JSON file(s)'
+    )
+    parser.add_argument(
+        '-o', '--output',
+        help='Output directory (relative to user.plot_directory)',
+    )
+    parser.add_argument(
+        '-b', '--blind',
+        nargs='*',
+        default=[],
+        help='Parameter names to blind (show as "?" with no error bars)'
+    )
+    
+    args = parser.parse_args()
+    output = args.output
+
+    if output is None:
+        list_fit_names = [os.path.basename(fit_file).replace(".json","") for fit_file in args.fit_files]
+        output_suffix = "_v_".join(list_fit_names)
+        output = f"fit_comparison_{output_suffix}"
+
+    output_dir = os.path.join(user.plot_directory, output)
+    
+    create_comparison_plot(args.fit_files, output_dir, args.blind)
+    print(f"Plots saved to {output_dir}")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add fit configs for V3 for all run2 eras.

Changes:
- PNN changed to the ones trained with early stopping
- Version names changed to v3
- Everything else are the same

Command used to run the fit: 
`python fit/Likelihood.py configs/unbinned_v3/unbinned_2018.yaml --rotate /scratch-cbe/users/robert.schoefbeck/SBIPDF/output/orthogonal_basis_unbinned_2018_unbinned_2018_v2.json`

Add the `--minos` flag for the fit script. 
- When `--minos` is not given, the fit runs as before: enable HESSE and disable MINOS.
- When `--minos` is given, HESSE is disabled and MINOS is used instead.