### PR TITLE
Updates for v5 - new PDF basis

### DIFF
--- a/configs/unbinned_v4/unbinned_2016.yaml
+++ b/configs/unbinned_v4/unbinned_2016.yaml
@@ -1,0 +1,1388 @@
+version: unbinned_2016_v4
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_pod_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: true
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 32
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+ 
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+  
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+      
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v4/unbinned_2016APV.yaml
+++ b/configs/unbinned_v4/unbinned_2016APV.yaml
@@ -1,0 +1,1387 @@
+version: unbinned_2016APV_v4
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_pod_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+      
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v4/unbinned_2017.yaml
+++ b/configs/unbinned_v4/unbinned_2017.yaml
@@ -1,0 +1,1384 @@
+version: unbinned_2017_v4
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_pod_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v4/unbinned_2018.yaml
+++ b/configs/unbinned_v4/unbinned_2018.yaml
@@ -1,0 +1,1384 @@
+version: unbinned_2018_v4
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_pod_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                  #parameters: [nu_mu_ren, nu_mu_fac] #FIXME
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+      l1: 0.0
+      l2: 0.0001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v4_TotalJES_EtaSplit_train/unbinned_2016.yaml
+++ b/configs/unbinned_v4_TotalJES_EtaSplit_train/unbinned_2016.yaml
@@ -1,0 +1,375 @@
+version: unbinned_2016_v4
+
+defaults:
+  module_samples: "data.samples_RunII_TotalJES_EtaSplit_train"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+
+              systematics:
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+
+jobs:
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5

--- a/configs/unbinned_v4_TotalJES_EtaSplit_train/unbinned_2016APV.yaml
+++ b/configs/unbinned_v4_TotalJES_EtaSplit_train/unbinned_2016APV.yaml
@@ -1,0 +1,375 @@
+version: unbinned_2016APV_v4
+
+defaults:
+  module_samples: "data.samples_RunII_TotalJES_EtaSplit_train"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+
+              systematics:
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+
+jobs:
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5

--- a/configs/unbinned_v4_TotalJES_EtaSplit_train/unbinned_2017.yaml
+++ b/configs/unbinned_v4_TotalJES_EtaSplit_train/unbinned_2017.yaml
@@ -1,0 +1,375 @@
+version: unbinned_2017_v4
+
+defaults:
+  module_samples: "data.samples_RunII_TotalJES_EtaSplit_train"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+
+              systematics:
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+
+jobs:
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5  

--- a/configs/unbinned_v4_TotalJES_EtaSplit_train/unbinned_2018.yaml
+++ b/configs/unbinned_v4_TotalJES_EtaSplit_train/unbinned_2018.yaml
@@ -1,0 +1,375 @@
+version: unbinned_2018_v4
+
+defaults:
+  module_samples: "data.samples_RunII_TotalJES_EtaSplit_train"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+
+              systematics:
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+
+jobs:
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5

--- a/configs/unbinned_v5/2016/unbinned_2016_1.yaml
+++ b/configs/unbinned_v5/2016/unbinned_2016_1.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_1_TTLep_pow_2016 
+                type: bit
+                parameters: [c0]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5/2016/unbinned_2016_2.yaml
+++ b/configs/unbinned_v5/2016/unbinned_2016_2.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_2_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5/2016/unbinned_2016_3.yaml
+++ b/configs/unbinned_v5/2016/unbinned_2016_3.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_3_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5/2016/unbinned_2016_4.yaml
+++ b/configs/unbinned_v5/2016/unbinned_2016_4.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_4_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5/2016/unbinned_2016_5.yaml
+++ b/configs/unbinned_v5/2016/unbinned_2016_5.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_5_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5/2016/unbinned_2016_6.yaml
+++ b/configs/unbinned_v5/2016/unbinned_2016_6.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_6_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5/2016/unbinned_2016_7.yaml
+++ b/configs/unbinned_v5/2016/unbinned_2016_7.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_7_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5/2016/unbinned_2016_8.yaml
+++ b/configs/unbinned_v5/2016/unbinned_2016_8.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_8_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5/2016/unbinned_2016_9.yaml
+++ b/configs/unbinned_v5/2016/unbinned_2016_9.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_9_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7, c8]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5/2016APV/unbinned_2016APV_1.yaml
+++ b/configs/unbinned_v5/2016APV/unbinned_2016APV_1.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016APV_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5/2016APV/unbinned_2016APV_2.yaml
+++ b/configs/unbinned_v5/2016APV/unbinned_2016APV_2.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016APV_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5/2016APV/unbinned_2016APV_3.yaml
+++ b/configs/unbinned_v5/2016APV/unbinned_2016APV_3.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016APV_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5/2016APV/unbinned_2016APV_4.yaml
+++ b/configs/unbinned_v5/2016APV/unbinned_2016APV_4.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016APV_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5/2016APV/unbinned_2016APV_5.yaml
+++ b/configs/unbinned_v5/2016APV/unbinned_2016APV_5.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016APV_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5/2016APV/unbinned_2016APV_6.yaml
+++ b/configs/unbinned_v5/2016APV/unbinned_2016APV_6.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016APV_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5/2016APV/unbinned_2016APV_7.yaml
+++ b/configs/unbinned_v5/2016APV/unbinned_2016APV_7.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016APV_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5/2016APV/unbinned_2016APV_8.yaml
+++ b/configs/unbinned_v5/2016APV/unbinned_2016APV_8.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016APV_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5/2016APV/unbinned_2016APV_9.yaml
+++ b/configs/unbinned_v5/2016APV/unbinned_2016APV_9.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016APV_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7, c8]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5/2017/unbinned_2017_1.yaml
+++ b/configs/unbinned_v5/2017/unbinned_2017_1.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2017_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_1_TTLep_pow_2017 
+                type: bit
+                parameters: [c0]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5/2017/unbinned_2017_2.yaml
+++ b/configs/unbinned_v5/2017/unbinned_2017_2.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2017_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_2_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5/2017/unbinned_2017_3.yaml
+++ b/configs/unbinned_v5/2017/unbinned_2017_3.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2017_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_3_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5/2017/unbinned_2017_4.yaml
+++ b/configs/unbinned_v5/2017/unbinned_2017_4.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2017_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_4_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5/2017/unbinned_2017_5.yaml
+++ b/configs/unbinned_v5/2017/unbinned_2017_5.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2017_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_5_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5/2017/unbinned_2017_6.yaml
+++ b/configs/unbinned_v5/2017/unbinned_2017_6.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2017_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_6_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5/2017/unbinned_2017_7.yaml
+++ b/configs/unbinned_v5/2017/unbinned_2017_7.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2017_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_7_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5/2017/unbinned_2017_8.yaml
+++ b/configs/unbinned_v5/2017/unbinned_2017_8.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2017_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_8_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5/2017/unbinned_2017_9.yaml
+++ b/configs/unbinned_v5/2017/unbinned_2017_9.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2017_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_9_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7, c8]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5/2018/unbinned_2018_1.yaml
+++ b/configs/unbinned_v5/2018/unbinned_2018_1.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2018_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_1_TTLep_pow_2018 
+                type: bit
+                parameters: [c0]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5/2018/unbinned_2018_2.yaml
+++ b/configs/unbinned_v5/2018/unbinned_2018_2.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2018_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_2_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5/2018/unbinned_2018_3.yaml
+++ b/configs/unbinned_v5/2018/unbinned_2018_3.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2018_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_3_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5/2018/unbinned_2018_4.yaml
+++ b/configs/unbinned_v5/2018/unbinned_2018_4.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2018_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_4_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5/2018/unbinned_2018_5.yaml
+++ b/configs/unbinned_v5/2018/unbinned_2018_5.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2018_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_5_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5/2018/unbinned_2018_6.yaml
+++ b/configs/unbinned_v5/2018/unbinned_2018_6.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2018_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_6_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5/2018/unbinned_2018_7.yaml
+++ b/configs/unbinned_v5/2018/unbinned_2018_7.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2018_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_7_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5/2018/unbinned_2018_8.yaml
+++ b/configs/unbinned_v5/2018/unbinned_2018_8.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2018_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_8_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5/2018/unbinned_2018_9.yaml
+++ b/configs/unbinned_v5/2018/unbinned_2018_9.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2018_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_9_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7, c8]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5/make_configs_automated.sh
+++ b/configs/unbinned_v5/make_configs_automated.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Create unbinned YAML configs for a given ERA (N=1..9).
+#
+# Motivation behind choices:
+# - Keep it simple and dependency-free: plain Bash + GNU sed.
+# - Safety first: do not overwrite existing files unless -f is provided.
+# - Correctness: replace only the first occurrence of
+#   "bit_pod_TTLep_pow_<ERA>" in each generated file.
+#
+# Input:
+# - Source: unbinned_<ERA>_original.yaml
+# - Output dir: <ERA>/ (must already exist)
+#
+# Output files:
+# - <ERA>/unbinned_<ERA>_1.yaml ... <ERA>/unbinned_<ERA>_9.yaml
+#
+# Usage:
+#   ./make_configs_automated.sh [-f] ERA
+#   -f   overwrite existing output files
+
+set -euo pipefail
+
+force_overwrite=false
+
+usage() {
+  echo "Usage: $(basename "$0") [-f] ERA"
+  echo "  -f    Overwrite existing output files"
+}
+
+while getopts ":fh" opt; do
+  case "$opt" in
+    f) force_overwrite=true ;;
+    h)
+      usage
+      exit 0
+      ;;
+    \?)
+      echo "Error: invalid option -$OPTARG" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+era="${1:-}"
+if [[ -z "$era" ]]; then
+  echo "Error: ERA is required." >&2
+  usage
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source_file="${script_dir}/unbinned_${era}_original.yaml"
+output_dir="${script_dir}/${era}"
+
+if [[ ! -f "$source_file" ]]; then
+  echo "Error: source file not found: $source_file" >&2
+  exit 1
+fi
+
+if [[ ! -d "$output_dir" ]]; then
+  echo "Error: output directory not found: $output_dir" >&2
+  exit 1
+fi
+
+old_text="bit_pod_TTLep_pow_${era}"
+old_parameters_text="\[c0, c1, c2, c3, c4, c5\]"
+
+for n in {1..9}; do
+  new_text="bit_NG_PDF4LHC21_${n}_TTLep_pow_${era}"
+  output_file="${output_dir}/unbinned_${era}_${n}.yaml"
+
+  if [[ -e "$output_file" && "$force_overwrite" != true ]]; then
+    echo "Skipping existing file: $output_file"
+    continue
+  fi
+
+  parameter_list="["
+  for ((i=0; i<n; i++)); do
+    if (( i > 0 )); then
+      parameter_list+=", "
+    fi
+    parameter_list+="c${i}"
+  done
+  parameter_list+="]"
+
+  sed \
+    -e "0,/${old_text}/s//${new_text}/" \
+    -e "0,/${old_parameters_text}/s//${parameter_list}/" \
+    "$source_file" > "$output_file"
+
+  echo "Created: $output_file"
+done

--- a/configs/unbinned_v5/unbinned_2016APV_original.yaml
+++ b/configs/unbinned_v5/unbinned_2016APV_original.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016APV_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_pod_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5/unbinned_2016APV_test.yaml
+++ b/configs/unbinned_v5/unbinned_2016APV_test.yaml
@@ -111,62 +111,30 @@ likelihood:
                   type: pnn
                   job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
                   parameters: [nu_CMS_res_j_5]
-                - id: CMS_scale_j_FlavorPureBottom
+                - id: CMS_scale_j_Total_EtaBin0
                   type: pnn
-                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
-                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
-                - id: CMS_scale_j_FlavorPureCharm
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
                   type: pnn
-                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
-                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
-                - id: CMS_scale_j_FlavorPureGluon
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
                   type: pnn
-                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
-                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
-                - id: CMS_scale_j_FlavorPureQuark
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
                   type: pnn
-                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
-                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
-                - id: CMS_scale_j_Regrouped_Absolute_2016APV
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
                   type: pnn
-                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
-                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
-                - id: CMS_scale_j_Regrouped_Absolute
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
                   type: pnn
-                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
-                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
-                - id: CMS_scale_j_Regrouped_BBEC1_2016APV
-                  type: pnn
-                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
-                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
-                - id: CMS_scale_j_Regrouped_BBEC1
-                  type: pnn
-                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
-                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
-                - id: CMS_scale_j_Regrouped_EC2_2016APV
-                  type: pnn
-                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
-                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
-                - id: CMS_scale_j_Regrouped_EC2
-                  type: pnn
-                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
-                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
-                - id: CMS_scale_j_Regrouped_HF_2016APV
-                  type: pnn
-                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
-                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
-                - id: CMS_scale_j_Regrouped_HF
-                  type: pnn
-                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
-                  parameters: [nu_CMS_scale_j_Regrouped_HF]
-                - id: CMS_scale_j_Regrouped_RelativeBal
-                  type: pnn
-                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
-                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
-                - id: CMS_scale_j_Regrouped_RelativeSample_2016
-                  type: pnn
-                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
-                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
                 - id: Uncl
                   type: pnn
                   job: pnn_TTLep_pow_2016APV_Uncl
@@ -175,7 +143,7 @@ likelihood:
 jobs:
   - id: bit_pod_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -198,7 +166,7 @@ jobs:
 
   - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -221,7 +189,7 @@ jobs:
 
   - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -244,7 +212,7 @@ jobs:
 
   - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -267,7 +235,7 @@ jobs:
 
   - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -290,7 +258,7 @@ jobs:
 
   - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -313,7 +281,7 @@ jobs:
 
   - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -336,7 +304,7 @@ jobs:
 
   - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -359,7 +327,7 @@ jobs:
 
   - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -382,7 +350,7 @@ jobs:
 
   - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -405,7 +373,7 @@ jobs:
 
   - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -428,7 +396,7 @@ jobs:
 
   - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -451,7 +419,7 @@ jobs:
 
   - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -474,7 +442,7 @@ jobs:
 
   - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -497,7 +465,7 @@ jobs:
 
   - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -520,7 +488,7 @@ jobs:
 
   - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -543,7 +511,7 @@ jobs:
 
   - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -566,7 +534,7 @@ jobs:
 
   - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -589,7 +557,7 @@ jobs:
 
   - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -612,7 +580,7 @@ jobs:
 
   - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -635,7 +603,7 @@ jobs:
 
   - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -658,7 +626,7 @@ jobs:
 
   - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -681,7 +649,7 @@ jobs:
 
   - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -704,7 +672,7 @@ jobs:
 
   - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -727,7 +695,7 @@ jobs:
 
   - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -750,7 +718,7 @@ jobs:
 
   - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -773,7 +741,7 @@ jobs:
 
   - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -796,7 +764,7 @@ jobs:
 
   - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
     type: bit
-    region: SR
+    region: SR_2016APV
     process: TTLep_pow_2016APV
     selection: null               # optional extra selection layered on top
     numba: True
@@ -820,14 +788,14 @@ jobs:
   - id: scaler_TTLep_pow_2016APV
     type: scaler
     process: TTLep_pow_2016APV
-    region: SR
+    region: SR_2016APV
     selection: null
     output:
       filename: "Scaler_TTLep_pow_2016APV.pkl"
 
   - id: icp_TTLep_pow_2016APV_L1Prefire
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_l1prefire]
     combinations: [[nu_l1prefire]]
     base_points:
@@ -847,7 +815,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
   - id: pnn_TTLep_pow_2016APV_L1Prefire
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_l1prefire]
     combinations: [[nu_l1prefire]]
     base_points:
@@ -881,7 +849,7 @@ jobs:
 
   - id: icp_TTLep_pow_2016APV_PU
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_pu]
     combinations: [[nu_pu]]
     base_points:
@@ -903,7 +871,7 @@ jobs:
 
   - id: pnn_TTLep_pow_2016APV_PU
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_pu]
     combinations: [[nu_pu]]
     base_points:
@@ -938,7 +906,7 @@ jobs:
 
   - id: icp_TTLep_pow_2016APV_MuSF
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_MuSF]
     combinations: [[nu_MuSF]]
     base_points:
@@ -959,7 +927,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_MuSF.pkl
   - id: pnn_TTLep_pow_2016APV_MuSF
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_MuSF]
     combinations: [[nu_MuSF]]
     base_points:
@@ -993,7 +961,7 @@ jobs:
       use_icp: icp_TTLep_pow_2016APV_MuSF
   - id: icp_TTLep_pow_2016APV_EleSF
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_EleSF]
     combinations: [[nu_EleSF]]
     base_points:
@@ -1013,7 +981,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_EleSF.pkl
   - id: pnn_TTLep_pow_2016APV_EleSF
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_EleSF]
     combinations: [[nu_EleSF]]
     base_points:
@@ -1046,7 +1014,7 @@ jobs:
       use_icp: icp_TTLep_pow_2016APV_EleSF
   - id: icp_TTLep_pow_2016APV_BTag_b
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_btag_b]
     combinations: [[nu_btag_b]]
     base_points:
@@ -1066,7 +1034,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_BTag_b.pkl
   - id: pnn_TTLep_pow_2016APV_BTag_b
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_btag_b]
     combinations: [[nu_btag_b]]
     base_points:
@@ -1099,7 +1067,7 @@ jobs:
       use_icp: icp_TTLep_pow_2016APV_BTag_b
   - id: icp_TTLep_pow_2016APV_BTag_l
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_btag_l]
     combinations: [[nu_btag_l]]
     base_points:
@@ -1120,7 +1088,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_BTag_l.pkl
   - id: pnn_TTLep_pow_2016APV_BTag_l
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_btag_l]
     combinations: [[nu_btag_l]]
     base_points:
@@ -1155,7 +1123,7 @@ jobs:
 
   - id: icp_TTLep_pow_2016APV_scales
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_mu_ren, nu_mu_fac]
     combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
           nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
@@ -1195,7 +1163,7 @@ jobs:
 
   - id: pnn_TTLep_pow_2016APV_scales
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_mu_ren, nu_mu_fac]
     combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
           nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
@@ -1248,7 +1216,7 @@ jobs:
 
   - id: icp_TTLep_pow_2016APV_showerISR
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_showerISR]
     combinations: [[nu_showerISR]]
     base_points:
@@ -1268,7 +1236,7 @@ jobs:
 
   - id: pnn_TTLep_pow_2016APV_showerISR
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_showerISR]
     combinations: [[nu_showerISR]]
     base_points:
@@ -1301,7 +1269,7 @@ jobs:
 
   - id: icp_TTLep_pow_2016APV_showerFSR
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_showerFSR]
     combinations: [[nu_showerFSR]]
     base_points:
@@ -1321,7 +1289,7 @@ jobs:
 
   - id: pnn_TTLep_pow_2016APV_showerFSR
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_showerFSR]
     combinations: [[nu_showerFSR]]
     base_points:
@@ -1354,7 +1322,7 @@ jobs:
 
   - id: icp_TTLep_pow_2016APV_alphaS
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_alphaS]
     combinations: [[nu_alphaS]]
     base_points:
@@ -1374,7 +1342,7 @@ jobs:
 
   - id: pnn_TTLep_pow_2016APV_alphaS
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_alphaS]
     combinations: [[nu_alphaS]]
     base_points:
@@ -1407,7 +1375,7 @@ jobs:
 
   - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_0]
     combinations: [[nu_CMS_res_j_0]]
     base_points:
@@ -1425,7 +1393,7 @@ jobs:
 
   - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_0]
     combinations: [[nu_CMS_res_j_0]]
     base_points:
@@ -1456,7 +1424,7 @@ jobs:
 
   - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_1]
     combinations: [[nu_CMS_res_j_1]]
     base_points:
@@ -1473,7 +1441,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_1]
     combinations: [[nu_CMS_res_j_1]]
     base_points:
@@ -1503,7 +1471,7 @@ jobs:
       use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
   - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_2]
     combinations: [[nu_CMS_res_j_2]]
     base_points:
@@ -1520,7 +1488,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_2]
     combinations: [[nu_CMS_res_j_2]]
     base_points:
@@ -1550,7 +1518,7 @@ jobs:
       use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
   - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_3]
     combinations: [[nu_CMS_res_j_3]]
     base_points:
@@ -1567,7 +1535,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_3]
     combinations: [[nu_CMS_res_j_3]]
     base_points:
@@ -1597,7 +1565,7 @@ jobs:
       use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
   - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_4]
     combinations: [[nu_CMS_res_j_4]]
     base_points:
@@ -1614,7 +1582,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_4]
     combinations: [[nu_CMS_res_j_4]]
     base_points:
@@ -1644,7 +1612,7 @@ jobs:
       use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
   - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_5]
     combinations: [[nu_CMS_res_j_5]]
     base_points:
@@ -1661,7 +1629,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
   - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_5]
     combinations: [[nu_CMS_res_j_5]]
     base_points:
@@ -1689,38 +1657,39 @@ jobs:
     extras:
       use_scaler: scaler_TTLep_pow_2016APV
       use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
-  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
     type: icp
-    region: SR
-    parameters: [nu_CMS_scale_j_FlavorPureBottom]
-    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
     base_points:
     - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
     - coords: [0]
       loader: TTLep_pow_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
-  
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
   
     train_ratio: true
     output:
-      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom.pkl
-  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
     type: pnn
-    region: SR
-    parameters: [nu_CMS_scale_j_FlavorPureBottom]
-    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
     base_points:
     - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_down
     - coords: [0]
       loader: TTLep_pow_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
-  
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0_up
   
     model:
       hidden_layers:
@@ -1737,37 +1706,40 @@ jobs:
       rebin: 2
     extras:
       use_scaler: scaler_TTLep_pow_2016APV
-      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
-  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
     type: icp
-    region: SR
-    parameters: [nu_CMS_scale_j_FlavorPureCharm]
-    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
     base_points:
     - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
     - coords: [0]
       loader: TTLep_pow_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
   
     train_ratio: true
     output:
-      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm.pkl
-  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
     type: pnn
-    region: SR
-    parameters: [nu_CMS_scale_j_FlavorPureCharm]
-    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
     base_points:
     - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_down
     - coords: [0]
       loader: TTLep_pow_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1_up
   
     model:
       hidden_layers:
@@ -1784,37 +1756,40 @@ jobs:
       rebin: 2
     extras:
       use_scaler: scaler_TTLep_pow_2016APV
-      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
-  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
     type: icp
-    region: SR
-    parameters: [nu_CMS_scale_j_FlavorPureGluon]
-    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
     base_points:
     - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
     - coords: [0]
       loader: TTLep_pow_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
   
     train_ratio: true
     output:
-      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon.pkl
-  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
     type: pnn
-    region: SR
-    parameters: [nu_CMS_scale_j_FlavorPureGluon]
-    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
     base_points:
     - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_down
     - coords: [0]
       loader: TTLep_pow_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2_up
   
     model:
       hidden_layers:
@@ -1831,37 +1806,40 @@ jobs:
       rebin: 2
     extras:
       use_scaler: scaler_TTLep_pow_2016APV
-      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
-  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
     type: icp
-    region: SR
-    parameters: [nu_CMS_scale_j_FlavorPureQuark]
-    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
     base_points:
     - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
     - coords: [0]
       loader: TTLep_pow_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
   
     train_ratio: true
     output:
-      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark.pkl
-  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
     type: pnn
-    region: SR
-    parameters: [nu_CMS_scale_j_FlavorPureQuark]
-    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
     base_points:
     - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_down
     - coords: [0]
       loader: TTLep_pow_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3_up
   
     model:
       hidden_layers:
@@ -1878,37 +1856,40 @@ jobs:
       rebin: 2
     extras:
       use_scaler: scaler_TTLep_pow_2016APV
-      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
-  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
     type: icp
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
     base_points:
     - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
     - coords: [0]
       loader: TTLep_pow_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
   
     train_ratio: true
     output:
-      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016.pkl
-  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
     type: pnn
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
     base_points:
     - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_down
     - coords: [0]
       loader: TTLep_pow_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4_up
   
     model:
       hidden_layers:
@@ -1925,39 +1906,40 @@ jobs:
       rebin: 2
     extras:
       use_scaler: scaler_TTLep_pow_2016APV
-      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
-  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
     type: icp
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
-    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
     base_points:
     - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
     - coords: [0]
       loader: TTLep_pow_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
-  
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
   
     train_ratio: true
     output:
-      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute.pkl
-  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
     type: pnn
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
-    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
     base_points:
     - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_down
     - coords: [0]
       loader: TTLep_pow_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
-  
+      loader: TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5_up
   
     model:
       hidden_layers:
@@ -1974,387 +1956,11 @@ jobs:
       rebin: 2
     extras:
       use_scaler: scaler_TTLep_pow_2016APV
-      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
-  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
-    type: icp
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
-  
-    train_ratio: true
-    output:
-      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016.pkl
-  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
-    type: pnn
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
-  
-    model:
-      hidden_layers:
-      - 128
-      - 128
-      activation: relu
-      initialize_zero: true
-    optim:
-      epochs: 200
-      phaseout_epochs: 50
-      learning_rate: 0.001
-    runtime:
-      n_split: 10
-      rebin: 2
-    extras:
-      use_scaler: scaler_TTLep_pow_2016APV
-      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
-  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
-    type: icp
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
-    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
-  
-    train_ratio: true
-    output:
-      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1.pkl
-  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
-    type: pnn
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
-    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
-  
-    model:
-      hidden_layers:
-      - 128
-      - 128
-      activation: relu
-      initialize_zero: true
-    optim:
-      epochs: 200
-      phaseout_epochs: 50
-      learning_rate: 0.001
-    runtime:
-      n_split: 10
-      rebin: 2
-    extras:
-      use_scaler: scaler_TTLep_pow_2016APV
-      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
-  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
-    type: icp
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
-  
-    train_ratio: true
-    output:
-      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016.pkl
-  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
-    type: pnn
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
-  
-    model:
-      hidden_layers:
-      - 128
-      - 128
-      activation: relu
-      initialize_zero: true
-    optim:
-      epochs: 200
-      phaseout_epochs: 50
-      learning_rate: 0.001
-    runtime:
-      n_split: 10
-      rebin: 2
-    extras:
-      use_scaler: scaler_TTLep_pow_2016APV
-      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
-  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
-    type: icp
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_EC2]
-    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
-  
-    train_ratio: true
-    output:
-      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2.pkl
-  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
-    type: pnn
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_EC2]
-    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
-  
-    model:
-      hidden_layers:
-      - 128
-      - 128
-      activation: relu
-      initialize_zero: true
-    optim:
-      epochs: 200
-      phaseout_epochs: 50
-      learning_rate: 0.001
-    runtime:
-      n_split: 10
-      rebin: 2
-    extras:
-      use_scaler: scaler_TTLep_pow_2016APV
-      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
-  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
-    type: icp
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
-  
-    train_ratio: true
-    output:
-      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016.pkl
-  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
-    type: pnn
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
-  
-    model:
-      hidden_layers:
-      - 128
-      - 128
-      activation: relu
-      initialize_zero: true
-    optim:
-      epochs: 200
-      phaseout_epochs: 50
-      learning_rate: 0.001
-    runtime:
-      n_split: 10
-      rebin: 2
-    extras:
-      use_scaler: scaler_TTLep_pow_2016APV
-      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
-  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
-    type: icp
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_HF]
-    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
-  
-    train_ratio: true
-    output:
-      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF.pkl
-  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
-    type: pnn
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_HF]
-    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
-  
-    model:
-      hidden_layers:
-      - 128
-      - 128
-      activation: relu
-      initialize_zero: true
-    optim:
-      epochs: 200
-      phaseout_epochs: 50
-      learning_rate: 0.001
-    runtime:
-      n_split: 10
-      rebin: 2
-    extras:
-      use_scaler: scaler_TTLep_pow_2016APV
-      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
-  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
-    type: icp
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
-    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
-  
-    train_ratio: true
-    output:
-      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal.pkl
-  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
-    type: pnn
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
-    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
-  
-    model:
-      hidden_layers:
-      - 128
-      - 128
-      activation: relu
-      initialize_zero: true
-    optim:
-      epochs: 200
-      phaseout_epochs: 50
-      learning_rate: 0.001
-    runtime:
-      n_split: 10
-      rebin: 2
-    extras:
-      use_scaler: scaler_TTLep_pow_2016APV
-      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
-  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
-    type: icp
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
-  
-    train_ratio: true
-    output:
-      filename: 
-        icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
-  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
-    type: pnn
-    region: SR
-    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
-    base_points:
-    - coords: [-1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
-    - coords: [0]
-      loader: TTLep_pow_2016APV
-      nominal: true
-    - coords: [1.0]
-      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
-  
-    model:
-      hidden_layers:
-      - 128
-      - 128
-      activation: relu
-      initialize_zero: true
-    optim:
-      epochs: 200
-      phaseout_epochs: 50
-      learning_rate: 0.001
-    runtime:
-      n_split: 10
-      rebin: 2
-    extras:
-      use_scaler: scaler_TTLep_pow_2016APV
-      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Total_EtaBin5
+
   - id: icp_TTLep_pow_2016APV_Uncl
     type: icp
-    region: SR
+    region: SR_2016APV
     parameters: [nu_Uncl]
     combinations: [[nu_Uncl]]
     base_points:
@@ -2371,7 +1977,7 @@ jobs:
       filename: icp_TTLep_pow_2016APV_Uncl.pkl
   - id: pnn_TTLep_pow_2016APV_Uncl
     type: pnn
-    region: SR
+    region: SR_2016APV
     parameters: [nu_Uncl]
     combinations: [[nu_Uncl]]
     base_points:

--- a/configs/unbinned_v5/unbinned_2016_original.yaml
+++ b/configs/unbinned_v5/unbinned_2016_original.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2016_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_pod_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5/unbinned_2017_original.yaml
+++ b/configs/unbinned_v5/unbinned_2017_original.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2017_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_pod_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5/unbinned_2018_original.yaml
+++ b/configs/unbinned_v5/unbinned_2018_original.yaml
@@ -1,0 +1,2008 @@
+version: unbinned_2018_v5
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_pod_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_Total_EtaBin0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+                  parameters: [nu_CMS_scale_j_Total_EtaBin0]
+                - id: CMS_scale_j_Total_EtaBin1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+                  parameters: [nu_CMS_scale_j_Total_EtaBin1]
+                - id: CMS_scale_j_Total_EtaBin2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+                  parameters: [nu_CMS_scale_j_Total_EtaBin2]
+                - id: CMS_scale_j_Total_EtaBin3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+                  parameters: [nu_CMS_scale_j_Total_EtaBin3]
+                - id: CMS_scale_j_Total_EtaBin4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+                  parameters: [nu_CMS_scale_j_Total_EtaBin4]
+                - id: CMS_scale_j_Total_EtaBin5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+                  parameters: [nu_CMS_scale_j_Total_EtaBin5]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+
+  # JES Eta-split bin 0
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin0]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin0_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin0
+
+  # JES Eta-split bin 1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin1]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin1
+
+  # JES Eta-split bin 2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin2]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin2
+
+  # JES Eta-split bin 3
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin3]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin3_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin3
+
+  # JES Eta-split bin 4
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin4]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin4_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin4
+
+  # JES Eta-split bin 5
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Total_EtaBin5]
+    combinations: [[nu_CMS_scale_j_Total_EtaBin5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Total_EtaBin5_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Total_EtaBin5
+
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016/unbinned_2016_1.yaml
+++ b/configs/unbinned_v5_CMSJES/2016/unbinned_2016_1.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_1_TTLep_pow_2016 
+                type: bit
+                parameters: [c0]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016/unbinned_2016_2.yaml
+++ b/configs/unbinned_v5_CMSJES/2016/unbinned_2016_2.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_2_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016/unbinned_2016_3.yaml
+++ b/configs/unbinned_v5_CMSJES/2016/unbinned_2016_3.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_3_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016/unbinned_2016_4.yaml
+++ b/configs/unbinned_v5_CMSJES/2016/unbinned_2016_4.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_4_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016/unbinned_2016_5.yaml
+++ b/configs/unbinned_v5_CMSJES/2016/unbinned_2016_5.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_5_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016/unbinned_2016_6.yaml
+++ b/configs/unbinned_v5_CMSJES/2016/unbinned_2016_6.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_6_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016/unbinned_2016_7.yaml
+++ b/configs/unbinned_v5_CMSJES/2016/unbinned_2016_7.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_7_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016/unbinned_2016_8.yaml
+++ b/configs/unbinned_v5_CMSJES/2016/unbinned_2016_8.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_8_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016/unbinned_2016_9.yaml
+++ b/configs/unbinned_v5_CMSJES/2016/unbinned_2016_9.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_NG_PDF4LHC21_9_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7, c8]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_1.yaml
+++ b/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_1.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016APV_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_2.yaml
+++ b/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_2.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016APV_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_3.yaml
+++ b/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_3.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016APV_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_4.yaml
+++ b/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_4.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016APV_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_5.yaml
+++ b/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_5.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016APV_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_6.yaml
+++ b/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_6.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016APV_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_7.yaml
+++ b/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_7.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016APV_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_8.yaml
+++ b/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_8.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016APV_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_9.yaml
+++ b/configs/unbinned_v5_CMSJES/2016APV/unbinned_2016APV_9.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016APV_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7, c8]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2017/unbinned_2017_1.yaml
+++ b/configs/unbinned_v5_CMSJES/2017/unbinned_2017_1.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2017_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_1_TTLep_pow_2017 
+                type: bit
+                parameters: [c0]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2017/unbinned_2017_2.yaml
+++ b/configs/unbinned_v5_CMSJES/2017/unbinned_2017_2.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2017_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_2_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2017/unbinned_2017_3.yaml
+++ b/configs/unbinned_v5_CMSJES/2017/unbinned_2017_3.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2017_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_3_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2017/unbinned_2017_4.yaml
+++ b/configs/unbinned_v5_CMSJES/2017/unbinned_2017_4.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2017_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_4_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2017/unbinned_2017_5.yaml
+++ b/configs/unbinned_v5_CMSJES/2017/unbinned_2017_5.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2017_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_5_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2017/unbinned_2017_6.yaml
+++ b/configs/unbinned_v5_CMSJES/2017/unbinned_2017_6.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2017_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_6_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2017/unbinned_2017_7.yaml
+++ b/configs/unbinned_v5_CMSJES/2017/unbinned_2017_7.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2017_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_7_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2017/unbinned_2017_8.yaml
+++ b/configs/unbinned_v5_CMSJES/2017/unbinned_2017_8.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2017_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_8_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2017/unbinned_2017_9.yaml
+++ b/configs/unbinned_v5_CMSJES/2017/unbinned_2017_9.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2017_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_NG_PDF4LHC21_9_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7, c8]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2018/unbinned_2018_1.yaml
+++ b/configs/unbinned_v5_CMSJES/2018/unbinned_2018_1.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2018_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_1_TTLep_pow_2018 
+                type: bit
+                parameters: [c0]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2018/unbinned_2018_2.yaml
+++ b/configs/unbinned_v5_CMSJES/2018/unbinned_2018_2.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2018_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_2_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2018/unbinned_2018_3.yaml
+++ b/configs/unbinned_v5_CMSJES/2018/unbinned_2018_3.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2018_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_3_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2018/unbinned_2018_4.yaml
+++ b/configs/unbinned_v5_CMSJES/2018/unbinned_2018_4.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2018_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_4_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2018/unbinned_2018_5.yaml
+++ b/configs/unbinned_v5_CMSJES/2018/unbinned_2018_5.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2018_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_5_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2018/unbinned_2018_6.yaml
+++ b/configs/unbinned_v5_CMSJES/2018/unbinned_2018_6.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2018_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_6_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2018/unbinned_2018_7.yaml
+++ b/configs/unbinned_v5_CMSJES/2018/unbinned_2018_7.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2018_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_7_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2018/unbinned_2018_8.yaml
+++ b/configs/unbinned_v5_CMSJES/2018/unbinned_2018_8.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2018_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_8_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/2018/unbinned_2018_9.yaml
+++ b/configs/unbinned_v5_CMSJES/2018/unbinned_2018_9.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2018_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_NG_PDF4LHC21_9_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5, c6, c7, c8]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/make_configs_automated.sh
+++ b/configs/unbinned_v5_CMSJES/make_configs_automated.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Create unbinned YAML configs for a given ERA (N=1..9).
+#
+# Motivation behind choices:
+# - Keep it simple and dependency-free: plain Bash + GNU sed.
+# - Safety first: do not overwrite existing files unless -f is provided.
+# - Correctness: replace only the first occurrence of
+#   "bit_pod_TTLep_pow_<ERA>" in each generated file.
+#
+# Input:
+# - Source: unbinned_<ERA>_original.yaml
+# - Output dir: <ERA>/ (must already exist)
+#
+# Output files:
+# - <ERA>/unbinned_<ERA>_1.yaml ... <ERA>/unbinned_<ERA>_9.yaml
+#
+# Usage:
+#   ./make_configs_automated.sh [-f] ERA
+#   -f   overwrite existing output files
+
+set -euo pipefail
+
+force_overwrite=false
+
+usage() {
+  echo "Usage: $(basename "$0") [-f] ERA"
+  echo "  -f    Overwrite existing output files"
+}
+
+while getopts ":fh" opt; do
+  case "$opt" in
+    f) force_overwrite=true ;;
+    h)
+      usage
+      exit 0
+      ;;
+    \?)
+      echo "Error: invalid option -$OPTARG" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+era="${1:-}"
+if [[ -z "$era" ]]; then
+  echo "Error: ERA is required." >&2
+  usage
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source_file="${script_dir}/unbinned_${era}_original.yaml"
+output_dir="${script_dir}/${era}"
+
+if [[ ! -f "$source_file" ]]; then
+  echo "Error: source file not found: $source_file" >&2
+  exit 1
+fi
+
+if [[ ! -d "$output_dir" ]]; then
+  echo "Error: output directory not found: $output_dir" >&2
+  exit 1
+fi
+
+old_text="bit_pod_TTLep_pow_${era}"
+old_parameters_text="\[c0, c1, c2, c3, c4, c5\]"
+
+for n in {1..9}; do
+  new_text="bit_NG_PDF4LHC21_${n}_TTLep_pow_${era}"
+  output_file="${output_dir}/unbinned_${era}_${n}.yaml"
+
+  if [[ -e "$output_file" && "$force_overwrite" != true ]]; then
+    echo "Skipping existing file: $output_file"
+    continue
+  fi
+
+  parameter_list="["
+  for ((i=0; i<n; i++)); do
+    if (( i > 0 )); then
+      parameter_list+=", "
+    fi
+    parameter_list+="c${i}"
+  done
+  parameter_list+="]"
+
+  sed \
+    -e "0,/${old_text}/s//${new_text}/" \
+    -e "0,/${old_parameters_text}/s//${parameter_list}/" \
+    "$source_file" > "$output_file"
+
+  echo "Created: $output_file"
+done

--- a/configs/unbinned_v5_CMSJES/unbinned_2016APV_original.yaml
+++ b/configs/unbinned_v5_CMSJES/unbinned_2016APV_original.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016APV_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_pod_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/unbinned_2016APV_test.yaml
+++ b/configs/unbinned_v5_CMSJES/unbinned_2016APV_test.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016APV_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016APV 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016APV]
+          classes: 
+            - id: TTLep_pow_2016APV
+              sample: TTLep_pow_2016APV
+              POI:
+                job: bit_pod_TTLep_pow_2016APV 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016APV
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016APV_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016APV.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016APV
+    type: bit
+    region: SR_2016APV
+    process: TTLep_pow_2016APV
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016APV.pkl"
+
+  - id: scaler_TTLep_pow_2016APV
+    type: scaler
+    process: TTLep_pow_2016APV
+    region: SR_2016APV
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016APV.pkl"
+
+  - id: icp_TTLep_pow_2016APV_L1Prefire
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016APV_L1Prefire
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_L1Prefire
+
+  - id: icp_TTLep_pow_2016APV_PU
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_PU.pkl
+
+  - id: pnn_TTLep_pow_2016APV_PU
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_PU
+
+  - id: icp_TTLep_pow_2016APV_MuSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_MuSF.pkl
+  - id: pnn_TTLep_pow_2016APV_MuSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_MuSF
+  - id: icp_TTLep_pow_2016APV_EleSF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_EleSF.pkl
+  - id: pnn_TTLep_pow_2016APV_EleSF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_EleSF
+  - id: icp_TTLep_pow_2016APV_BTag_b
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_b
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_b
+  - id: icp_TTLep_pow_2016APV_BTag_l
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016APV_BTag_l
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_BTag_l
+
+  - id: icp_TTLep_pow_2016APV_scales
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_scales.pkl
+
+  - id: pnn_TTLep_pow_2016APV_scales
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016APV
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_scales
+
+  - id: icp_TTLep_pow_2016APV_showerISR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerISR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerISR
+
+  - id: icp_TTLep_pow_2016APV_showerFSR
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016APV_showerFSR
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_showerFSR
+
+  - id: icp_TTLep_pow_2016APV_alphaS
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016APV_alphaS
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016APV
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016APV
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_alphaS
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV.pkl
+
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_0_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_0_2016APV
+
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_1_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_1_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_2_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_2_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_3_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_3_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_4_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_4_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_res_j_5_2016APV_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_res_j_5_2016APV
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016APV_Uncl
+    type: icp
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016APV_Uncl.pkl
+  - id: pnn_TTLep_pow_2016APV_Uncl
+    type: pnn
+    region: SR_2016APV
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016APV_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016APV
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016APV_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+      use_icp: icp_TTLep_pow_2016APV_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/unbinned_2016_original.yaml
+++ b/configs/unbinned_v5_CMSJES/unbinned_2016_original.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2016_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2016 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2016]
+          classes: 
+            - id: TTLep_pow_2016
+              sample: TTLep_pow_2016
+              POI:
+                job: bit_pod_TTLep_pow_2016 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2016_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2016.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2016
+    type: bit
+    region: SR_2016
+    process: TTLep_pow_2016
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2016.pkl"
+
+  - id: scaler_TTLep_pow_2016
+    type: scaler
+    process: TTLep_pow_2016
+    region: SR_2016
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2016.pkl"
+
+  - id: icp_TTLep_pow_2016_L1Prefire
+    type: icp
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2016_L1Prefire
+    type: pnn
+    region: SR_2016
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_L1Prefire
+
+  - id: icp_TTLep_pow_2016_PU
+    type: icp
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_PU.pkl
+
+  - id: pnn_TTLep_pow_2016_PU
+    type: pnn
+    region: SR_2016
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_PU
+
+  - id: icp_TTLep_pow_2016_MuSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_MuSF.pkl
+  - id: pnn_TTLep_pow_2016_MuSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_MuSF
+  - id: icp_TTLep_pow_2016_EleSF
+    type: icp
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_EleSF.pkl
+  - id: pnn_TTLep_pow_2016_EleSF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_EleSF
+  - id: icp_TTLep_pow_2016_BTag_b
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_b.pkl
+  - id: pnn_TTLep_pow_2016_BTag_b
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_b
+  - id: icp_TTLep_pow_2016_BTag_l
+    type: icp
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_BTag_l.pkl
+  - id: pnn_TTLep_pow_2016_BTag_l
+    type: pnn
+    region: SR_2016
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_BTag_l
+
+  - id: icp_TTLep_pow_2016_scales
+    type: icp
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_scales.pkl
+
+  - id: pnn_TTLep_pow_2016_scales
+    type: pnn
+    region: SR_2016
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2016
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_scales
+
+  - id: icp_TTLep_pow_2016_showerISR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerISR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerISR
+
+  - id: icp_TTLep_pow_2016_showerFSR
+    type: icp
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2016_showerFSR
+    type: pnn
+    region: SR_2016
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_showerFSR
+
+  - id: icp_TTLep_pow_2016_alphaS
+    type: icp
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2016_alphaS
+    type: pnn
+    region: SR_2016
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2016
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2016
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_alphaS
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_0_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_0_2016.pkl
+
+  - id: pnn_TTLep_pow_2016_CMS_res_j_0_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_0_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_0_2016
+
+  - id: icp_TTLep_pow_2016_CMS_res_j_1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_1_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_2_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_3_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_3_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_3_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_3_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_3_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_4_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_4_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_4_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_4_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_4_2016
+  - id: icp_TTLep_pow_2016_CMS_res_j_5_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_res_j_5_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_res_j_5_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_res_j_5_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_res_j_5_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2016
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2016_Uncl
+    type: icp
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2016_Uncl.pkl
+  - id: pnn_TTLep_pow_2016_Uncl
+    type: pnn
+    region: SR_2016
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2016_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2016
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2016_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2016
+      use_icp: icp_TTLep_pow_2016_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/unbinned_2017_original.yaml
+++ b/configs/unbinned_v5_CMSJES/unbinned_2017_original.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2017_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2017 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2017]
+          classes: 
+            - id: TTLep_pow_2017
+              sample: TTLep_pow_2017
+              POI:
+                job: bit_pod_TTLep_pow_2017 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2017
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2017_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2017.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2017
+    type: bit
+    region: SR_2017
+    process: TTLep_pow_2017
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2017.pkl"
+
+  - id: scaler_TTLep_pow_2017
+    type: scaler
+    process: TTLep_pow_2017
+    region: SR_2017
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2017.pkl"
+
+  - id: icp_TTLep_pow_2017_L1Prefire
+    type: icp
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2017_L1Prefire
+    type: pnn
+    region: SR_2017
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_L1Prefire
+
+  - id: icp_TTLep_pow_2017_PU
+    type: icp
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_PU.pkl
+
+  - id: pnn_TTLep_pow_2017_PU
+    type: pnn
+    region: SR_2017
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_PU
+
+  - id: icp_TTLep_pow_2017_MuSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_MuSF.pkl
+  - id: pnn_TTLep_pow_2017_MuSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_MuSF
+  - id: icp_TTLep_pow_2017_EleSF
+    type: icp
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_EleSF.pkl
+  - id: pnn_TTLep_pow_2017_EleSF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_EleSF
+  - id: icp_TTLep_pow_2017_BTag_b
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_b.pkl
+  - id: pnn_TTLep_pow_2017_BTag_b
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_b
+  - id: icp_TTLep_pow_2017_BTag_l
+    type: icp
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_BTag_l.pkl
+  - id: pnn_TTLep_pow_2017_BTag_l
+    type: pnn
+    region: SR_2017
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_BTag_l
+
+  - id: icp_TTLep_pow_2017_scales
+    type: icp
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_scales.pkl
+
+  - id: pnn_TTLep_pow_2017_scales
+    type: pnn
+    region: SR_2017
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2017
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_scales
+
+  - id: icp_TTLep_pow_2017_showerISR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerISR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerISR
+
+  - id: icp_TTLep_pow_2017_showerFSR
+    type: icp
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2017_showerFSR
+    type: pnn
+    region: SR_2017
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_showerFSR
+
+  - id: icp_TTLep_pow_2017_alphaS
+    type: icp
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2017_alphaS
+    type: pnn
+    region: SR_2017
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2017
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2017
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_alphaS
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_0_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_0_2017.pkl
+
+  - id: pnn_TTLep_pow_2017_CMS_res_j_0_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_0_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_0_2017
+
+  - id: icp_TTLep_pow_2017_CMS_res_j_1_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_1_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_1_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_1_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_1_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_2_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_2_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_2_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_2_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_2_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_3_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_3_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_3_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_3_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_3_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_4_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_4_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_4_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_4_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_4_2017
+  - id: icp_TTLep_pow_2017_CMS_res_j_5_2017
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_res_j_5_2017.pkl
+  - id: pnn_TTLep_pow_2017_CMS_res_j_5_2017
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_res_j_5_2017_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_res_j_5_2017
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2017
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2017_Uncl
+    type: icp
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2017_Uncl.pkl
+  - id: pnn_TTLep_pow_2017_Uncl
+    type: pnn
+    region: SR_2017
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2017_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2017
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2017_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2017
+      use_icp: icp_TTLep_pow_2017_Uncl
+  

--- a/configs/unbinned_v5_CMSJES/unbinned_2018_original.yaml
+++ b/configs/unbinned_v5_CMSJES/unbinned_2018_original.yaml
@@ -1,0 +1,2402 @@
+version: unbinned_2018_v5_CMSJES
+
+defaults:
+  module_samples: "data.samples_RunII"
+  default_features:
+    - TOP_KINEMATICS
+    - LEPTON_KINEMATICS
+    - ASYMMETRY
+
+  splitting:
+    enabled: true
+    uid_fields: ["run", "luminosityBlock", "event"]
+    seed: 42
+    n_buckets: 10000 
+
+    scheme:
+      pnn_train:     { fraction: 0.50 }
+      pnn_val:       { fraction: 0.10 }
+      c2st_train:    { fraction: 0.15 }
+      c2st_val:      { fraction: 0.05 }
+      final_eval:    { fraction: 0.20 }
+
+  early_stopping:
+    enabled: true
+    patience: 20        # same as current hard-coded
+    min_delta: 0.0      # improvement threshold; keep 0.0 to match current behavior
+    mode: "min"         # val_loss should decrease
+    warmup_epochs: 0    # optional: do not early-stop before this epoch
+
+likelihood:
+    regions:
+        - id: SR_2018 
+          classifier:
+            type: null
+            id: null    # no classifier needed for a single process
+            asimov: [TTLep_pow_2018]
+          classes: 
+            - id: TTLep_pow_2018
+              sample: TTLep_pow_2018
+              POI:
+                job: bit_pod_TTLep_pow_2018 
+                type: bit
+                parameters: [c0, c1, c2, c3, c4, c5]
+
+              systematics:
+                - id: Normalization_TTLep
+                  type: lnN
+                  value: 0.05
+                  parameters: [nu_norm_TTLep]
+                - id: L1Prefire
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_L1Prefire
+                  parameters: [nu_l1prefire]
+                - id: PU
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_PU
+                  parameters: [nu_pu]
+                - id: MuSF 
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_MuSF
+                  parameters: [nu_MuSF]
+                - id: EleSF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_EleSF
+                  parameters: [nu_EleSF]
+                - id: BTag_b
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_b
+                  parameters: [nu_btag_b]
+                - id: BTag_l
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_BTag_l
+                  parameters: [nu_btag_l]
+                - id: Scales
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_scales
+                  parameters: [nu_mu_ren, nu_mu_fac]
+                - id: ShowerISR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerISR
+                  parameters: [nu_showerISR]
+                - id: ShowerFSR
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_showerFSR
+                  parameters: [nu_showerFSR]
+                - id: AlphaS
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_alphaS
+                  parameters: [nu_alphaS]
+                - id: CMS_res_j_0
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+                  parameters: [nu_CMS_res_j_0]
+                - id: CMS_res_j_1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+                  parameters: [nu_CMS_res_j_1]
+                - id: CMS_res_j_2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+                  parameters: [nu_CMS_res_j_2]
+                - id: CMS_res_j_3
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+                  parameters: [nu_CMS_res_j_3]
+                - id: CMS_res_j_4
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+                  parameters: [nu_CMS_res_j_4]
+                - id: CMS_res_j_5
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+                  parameters: [nu_CMS_res_j_5]
+                - id: CMS_scale_j_FlavorPureBottom
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+                  parameters: [nu_CMS_scale_j_FlavorPureBottom]
+                - id: CMS_scale_j_FlavorPureCharm
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+                  parameters: [nu_CMS_scale_j_FlavorPureCharm]
+                - id: CMS_scale_j_FlavorPureGluon
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+                  parameters: [nu_CMS_scale_j_FlavorPureGluon]
+                - id: CMS_scale_j_FlavorPureQuark
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+                  parameters: [nu_CMS_scale_j_FlavorPureQuark]
+                - id: CMS_scale_j_Regrouped_Absolute_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                - id: CMS_scale_j_Regrouped_Absolute
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+                - id: CMS_scale_j_Regrouped_BBEC1_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                - id: CMS_scale_j_Regrouped_BBEC1
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+                - id: CMS_scale_j_Regrouped_EC2_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                - id: CMS_scale_j_Regrouped_EC2
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2]
+                - id: CMS_scale_j_Regrouped_HF_2018
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                - id: CMS_scale_j_Regrouped_HF
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+                  parameters: [nu_CMS_scale_j_Regrouped_HF]
+                - id: CMS_scale_j_Regrouped_RelativeBal
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                - id: Uncl
+                  type: pnn
+                  job: pnn_TTLep_pow_2018_Uncl
+                  parameters: [nu_Uncl]
+
+jobs:
+  - id: bit_pod_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1, 2, 4, 5, 10, 12]
+      pdf_type: PODBasis
+      pdf_basis: 250503_pod_basis_40k
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_pod_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_PDF4LHC21_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_PDF4LHC21 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_PDF4LHC21_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF40_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF40 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF40_9_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_1_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_1_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_2_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_2_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_3_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_3_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_4_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_4_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_5_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_5_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_6_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_6_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_7_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_7_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_8_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_8_TTLep_pow_2018.pkl"
+
+  - id: bit_NG_NNPDF31_9_TTLep_pow_2018
+    type: bit
+    region: SR_2018
+    process: TTLep_pow_2018
+    selection: null               # optional extra selection layered on top
+    numba: True
+    pdf:
+      pdf_n: [1,2,3,4,5,6,7,8,9]
+      pdf_type: PODBasis
+      pdf_basis: gluon_POD_nongluon_NNPDF31_hessian 
+    model:
+      n_trees: 200
+      learning_rate: 0.2
+      loss: MSE                   # or "CrossEntropy"
+      learn_global_score: true
+      split_mode: "binned"
+      n_bins: 256
+      quantile_bins: true  # if True: quantile edges; else uniform edges
+    runtime:
+      training_plots: true        # keep if you want training plots
+    output:
+      filename: "BIT_NG_NNPDF31_9_TTLep_pow_2018.pkl"
+
+  - id: scaler_TTLep_pow_2018
+    type: scaler
+    process: TTLep_pow_2018
+    region: SR_2018
+    selection: null
+    output:
+      filename: "Scaler_TTLep_pow_2018.pkl"
+
+  - id: icp_TTLep_pow_2018_L1Prefire
+    type: icp
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_L1Prefire.pkl
+  - id: pnn_TTLep_pow_2018_L1Prefire
+    type: pnn
+    region: SR_2018
+    parameters: [nu_l1prefire]
+    combinations: [[nu_l1prefire]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Dn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["L1PreFiringWeight_Nom"]
+      addweights: ["L1PreFiringWeight_Up"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_L1Prefire
+
+  - id: icp_TTLep_pow_2018_PU
+    type: icp
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_PU.pkl
+
+  - id: pnn_TTLep_pow_2018_PU
+    type: pnn
+    region: SR_2018
+    parameters: [nu_pu]
+    combinations: [[nu_pu]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["Pileup_SF"]
+      addweights: ["Pileup_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_PU
+
+  - id: icp_TTLep_pow_2018_MuSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_MuSF.pkl
+  - id: pnn_TTLep_pow_2018_MuSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_MuSF]
+    combinations: [[nu_MuSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepMu_SF"]
+      addweights: ["lepMu_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_MuSF
+  - id: icp_TTLep_pow_2018_EleSF
+    type: icp
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_EleSF.pkl
+  - id: pnn_TTLep_pow_2018_EleSF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_EleSF]
+    combinations: [[nu_EleSF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["lepEle_SF"]
+      addweights: ["lepEle_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_EleSF
+  - id: icp_TTLep_pow_2018_BTag_b
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_b.pkl
+  - id: pnn_TTLep_pow_2018_BTag_b
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_b]
+    combinations: [[nu_btag_b]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_b
+  - id: icp_TTLep_pow_2018_BTag_l
+    type: icp
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_BTag_l.pkl
+  - id: pnn_TTLep_pow_2018_BTag_l
+    type: pnn
+    region: SR_2018
+    parameters: [nu_btag_l]
+    combinations: [[nu_btag_l]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
+    - coords: [0.0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018
+      removeweights: ["btagSF_fixedWP_SF"]
+      addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_BTag_l
+
+  - id: icp_TTLep_pow_2018_scales
+    type: icp
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_scales.pkl
+
+  - id: pnn_TTLep_pow_2018_scales
+    type: pnn
+    region: SR_2018
+    parameters: [nu_mu_ren, nu_mu_fac]
+    combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
+          nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
+    base_points:
+    - coords: [-1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac0p5"]
+    - coords: [-1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac1p0"]
+    - coords: [-1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren0p5_fac2p0"]
+    - coords: [0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac0p5"]
+    - coords: [0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac1p0"]
+      nominal: true
+    - coords: [0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren1p0_fac2p0"]
+    - coords: [1.0, -1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac0p5"]
+    - coords: [1.0, 0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac1p0"]
+    - coords: [1.0, 1.0]
+      loader: TTLep_pow_2018
+      addweights: ["scale_ren2p0_fac2p0"]
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_scales
+
+  - id: icp_TTLep_pow_2018_showerISR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerISR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerISR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerISR]
+    combinations: [[nu_showerISR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerISR
+
+  - id: icp_TTLep_pow_2018_showerFSR
+    type: icp
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_showerFSR.pkl
+
+  - id: pnn_TTLep_pow_2018_showerFSR
+    type: pnn
+    region: SR_2018
+    parameters: [nu_showerFSR]
+    combinations: [[nu_showerFSR]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr0p5_fsr1p0"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["shower_isr2p0_fsr1p0"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_showerFSR
+
+  - id: icp_TTLep_pow_2018_alphaS
+    type: icp
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_alphaS.pkl
+
+  - id: pnn_TTLep_pow_2018_alphaS
+    type: pnn
+    region: SR_2018
+    parameters: [nu_alphaS]
+    combinations: [[nu_alphaS]]
+    base_points:
+      - coords: [-1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_dn"]
+      - coords: [0]
+        loader: TTLep_pow_2018
+        nominal: true
+      - coords: [1.0]
+        loader: TTLep_pow_2018
+        addweights: ["pdf_alphas_up"]
+ 
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_alphaS
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_0_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_0_2018.pkl
+
+  - id: pnn_TTLep_pow_2018_CMS_res_j_0_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_0]
+    combinations: [[nu_CMS_res_j_0]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_0_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_0_2018
+
+  - id: icp_TTLep_pow_2018_CMS_res_j_1_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_1_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_1_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_1]
+    combinations: [[nu_CMS_res_j_1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_1_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_1_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_2_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_2_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_2_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_2]
+    combinations: [[nu_CMS_res_j_2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_2_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_2_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_3_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_3_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_3_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_3]
+    combinations: [[nu_CMS_res_j_3]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_3_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_3_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_4_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_4_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_4_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_4]
+    combinations: [[nu_CMS_res_j_4]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_4_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_4_2018
+  - id: icp_TTLep_pow_2018_CMS_res_j_5_2018
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_res_j_5_2018.pkl
+  - id: pnn_TTLep_pow_2018_CMS_res_j_5_2018
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_res_j_5]
+    combinations: [[nu_CMS_res_j_5]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_res_j_5_2018_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_res_j_5_2018
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureBottom]
+    combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureBottom_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureBottom
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureCharm]
+    combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureCharm_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureCharm
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureGluon]
+    combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureGluon_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureGluon
+  - id: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_FlavorPureQuark]
+    combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_FlavorPureQuark_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_FlavorPureQuark
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute_up
+  
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_EC2_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_EC2
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_HF_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_HF
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: icp
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    train_ratio: true
+    output:
+      filename: 
+        icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+  - id: pnn_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+    type: pnn
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TTLep_pow_2018_Uncl
+    type: icp
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    train_ratio: true
+    output:
+      filename: icp_TTLep_pow_2018_Uncl.pkl
+  - id: pnn_TTLep_pow_2018_Uncl
+    type: pnn
+    region: SR_2018
+    parameters: [nu_Uncl]
+    combinations: [[nu_Uncl]]
+    base_points:
+    - coords: [-1.0]
+      loader: TTLep_pow_2018_Uncl_down
+    - coords: [0]
+      loader: TTLep_pow_2018
+      nominal: true
+    - coords: [1.0]
+      loader: TTLep_pow_2018_Uncl_up
+  
+    model:
+      hidden_layers:
+      - 128
+      - 128
+      activation: relu
+      initialize_zero: true
+    optim:
+      epochs: 200
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      n_split: 10
+      rebin: 2
+    extras:
+      use_scaler: scaler_TTLep_pow_2018
+      use_icp: icp_TTLep_pow_2018_Uncl
+  

--- a/data/samples_RunII_TotalJES_EtaSplit_train.py
+++ b/data/samples_RunII_TotalJES_EtaSplit_train.py
@@ -1,0 +1,493 @@
+# File: data/samples_RunII.py
+from __future__ import annotations
+from typing import Dict, List, Optional
+
+import os
+from pathlib import Path
+import sys
+
+sys.path.insert(0, '..')
+sys.path.insert(0, '../..')
+
+from data.RDataLoader import RDataLoader
+from data.SelectionView import SelectionView
+
+import observables
+from systematics_RunII import SYSTEMATICS
+import common.user as user
+
+# Use Path so that BASE_DIRECTORY / "2018" / "file.root" works.
+BASE_DIRECTORY = Path(
+    "/groups/hephy/cms/ricardo.barrue/CMGRDF_ntuples_TotalJES_EtaSplit/v2-3-2_nJ2p_nB2p_2l/"
+)
+ERAS = ["2016", "2016APV", "2017", "2018", "RunII"]
+
+GROUPS = {
+
+}
+
+process_labels = {
+    "TTLep_pow":  "t#bar{t} (2l)",
+}
+
+# -----------------------------
+# Base sample (nominal)
+# -----------------------------
+_base = RDataLoader(
+    input_paths=[
+        str(BASE_DIRECTORY / "2018" / "TTLep_pow_nominal.root"),
+    ],
+    tree_name="Events",
+    branches=(
+        observables.OBSERVERS
+        + observables.TOP_KINEMATICS
+        + observables.LEPTON_KINEMATICS
+        + observables.ASYMMETRY
+    ),
+    selection=None,
+    n_split=1,
+    splitting_strategy="events",
+    strict_branches=False,
+    weight_branches=[
+        "weight",
+        "L1PreFiringWeight_Nom",
+        "JetPUID_SF",
+        "Pileup_SF",
+        "btagSF_fixedWP_SF",
+        "lepEle_SF",
+        "lepMu_SF",
+    ],
+    feature_names=(
+        observables.TOP_KINEMATICS
+        + observables.LEPTON_KINEMATICS
+        + observables.ASYMMETRY
+    ),
+    observer_names=observables.OBSERVERS,
+)
+#FIXME The RDataloader should allow string based selections already in the constructor. Also, & binds stronger than &&!!! So parenthesis are needed.
+_base.addSelection( "(lep1_pt>20) & (tr_isvalid>0) & (isOS>0) & (offZ>0)", required_branches = ["lep1_pt", "isOS", "offZ", "tr_isvalid"]) 
+
+delphes_OBSERVERS = ["Generator_x1", "Generator_x2", "Generator_id1", "Generator_id2", "Generator_scalePDF", "tr_isvalid"]
+tt2l_delphes = RDataLoader( 
+        input_paths=[ 
+            "/scratch-cbe/users/robert.schoefbeck/TT2lUnbinned/nanoTuples/delphes/v1/TTLep_pow_selected/TTLep_pow_0.root",
+            "/scratch-cbe/users/robert.schoefbeck/TT2lUnbinned/nanoTuples/delphes/v1/TTLep_pow_selected/TTLep_pow_1.root",
+            "/scratch-cbe/users/robert.schoefbeck/TT2lUnbinned/nanoTuples/delphes/v1/TTLep_pow_selected/TTLep_pow_2.root",
+            "/scratch-cbe/users/robert.schoefbeck/TT2lUnbinned/nanoTuples/delphes/v1/TTLep_pow_selected/TTLep_pow_3.root",
+            "/scratch-cbe/users/robert.schoefbeck/TT2lUnbinned/nanoTuples/delphes/v1/TTLep_pow_selected/TTLep_pow_4.root",
+            ],
+    tree_name="Events",
+    branches=(
+        delphes_OBSERVERS 
+        + observables.TOP_KINEMATICS
+        + observables.LEPTON_KINEMATICS
+        + observables.ASYMMETRY
+    ),
+    selection=None,
+    n_split=1,
+    splitting_strategy="events",
+    strict_branches=True,
+    weight_branches=[
+        "weight1fb",
+    ],
+    feature_names=(
+        observables.TOP_KINEMATICS
+        + observables.LEPTON_KINEMATICS
+        + observables.ASYMMETRY
+    ),
+    observer_names=delphes_OBSERVERS,
+)
+#tt2l_delphes.addSelection( "(lep1_pt>20) & (tr_isvalid>0) & (isOS>0) & (offZ>0)", required_branches = ["lep1_pt", "isOS", "offZ", "tr_isvalid"]) 
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+def _parse_name(name: str) -> tuple[str, str, Optional[str]]:
+    """
+    Parse a name of the form
+
+        <process>_<era>
+        <process>_<era>_<variation>
+
+    where <process> may contain underscores and
+    <era> is one of ERAS.
+
+    Returns (process, era, tag) where tag can be None (→ nominal).
+    """
+    found_era: Optional[str] = None
+    process: Optional[str] = None
+    tag: Optional[str] = None
+
+    # Match longer eras first (so '2016APV' wins over '2016').
+    for era in sorted(ERAS, key=len, reverse=True):
+        middle = f"_{era}_"
+        end = f"_{era}"
+
+        if middle in name:
+            idx = name.index(middle)
+            process = name[:idx]
+            tag = name[idx + len(middle) :]  # everything after "<era>_"
+            found_era = era
+            break
+        elif name.endswith(end):
+            idx = name.rfind(end)
+            process = name[:idx]
+            tag = None  # nominal
+            found_era = era
+            break
+
+    if not found_era or not process:
+        raise ValueError(
+            f"Could not decode sample name {name!r}.\n"
+            "Expected pattern '<process>_<era>' or '<process>_<era>_<variation>'.\n"
+            f"Known eras: {', '.join(ERAS)}\n"
+            "Examples:\n"
+            "  TTSemi_pow_2018\n"
+            "  TTSemi_pow_2018_CMS_res_j_0_2018_down\n"
+            "  T_tWch_noFullyHad_2018_CMS_res_j_0_2018_up"
+        )
+
+    return process, found_era, tag
+
+
+def _available_tags_for(process: str, era: str) -> List[str]:
+    """
+    List all tags actually present on disk for a given process and era,
+    based on files matching '<process>_<tag>.root'.
+    """
+    root_dir = BASE_DIRECTORY / era
+    if not root_dir.is_dir():
+        return []
+
+    prefix = f"{process}_"
+    tags = set()
+    for f in root_dir.glob("*.root"):
+        stem = f.stem
+        if stem.startswith(prefix):
+            tags.add(stem[len(prefix) :])
+
+    return sorted(tags)
+
+
+def _available_files_for_era(era: str) -> List[str]:
+    """
+    List all ROOT filenames for a given era directory.
+    Useful for error messages when the process itself is wrong.
+    """
+    root_dir = BASE_DIRECTORY / era
+    if not root_dir.is_dir():
+        return []
+
+    return sorted(f.name for f in root_dir.glob("*.root"))
+
+
+# ----------------------------------------------------------------------
+# Helpers for making variations
+# ----------------------------------------------------------------------
+
+def _make_variation(process: str, era: str, tag: str, BASE_DIRECTORY: str = BASE_DIRECTORY) -> RDataLoader:
+    """
+    Construct a variation from a process, era, and tag, e.g.
+
+        process = "TTSemi_pow"
+        era     = "2018"
+        tag     = "CMS_res_j_0_2018_down"
+
+    Path on disk:
+        <BASE_DIRECTORY>/<era>/<process>_<tag>.root
+
+    The new loader is cloned from the baseline sample `_base`.
+    """
+    if not tag:
+        tag = "nominal"
+
+    eras = [era] if era!="RunII" else ["2016", "2016APV", "2017", "2018"]
+
+    rootfiles = []
+    for era in eras:
+        root_dir = BASE_DIRECTORY / era
+        rootfile = root_dir / f"{process}_{tag}.root"
+
+        if not root_dir.is_dir():
+            raise FileNotFoundError(
+                f"Era directory '{root_dir}' does not exist "
+                f"(process={process!r}, tag={tag!r})."
+            )
+
+        if not rootfile.is_file():
+            raise FileNotFoundError(
+                f"Did not find ROOT file for process={process!r}, era={era!r}, tag={tag!r}.\n"
+                f"Expected file: {rootfile}"
+            )
+        rootfiles.append(str(rootfile))
+
+    return _base.clone_from_files(rootfiles)
+
+def _make_group_variation(group: str, era: str, tag: str, BASE_DIRECTORY: str = BASE_DIRECTORY) -> RDataLoader:
+    """
+    Construct a variation for a group of processes, e.g.
+
+        group = "singleTop"
+        era   = "2016"
+        tag   = "nominal"
+
+    This will look for all files
+        <BASE_DIRECTORY>/<era>/<process>_<tag>.root
+    for each process in GROUPS[group].
+    """
+    if not tag:
+        tag = "nominal"
+
+    if group not in GROUPS:
+        raise FileNotFoundError(
+            f"Unknown group {group!r}. Known groups: {', '.join(GROUPS.keys())}"
+        )
+
+    eras = [era] if era!="RunII" else ["2016", "2016APV", "2017", "2018"]
+
+    members = GROUPS[group]
+    missing = []
+    existing = []
+
+    for era in eras:
+        root_dir = BASE_DIRECTORY / era
+        if not root_dir.is_dir():
+            raise FileNotFoundError(
+                f"Era directory '{root_dir}' does not exist for group={group!r}, tag={tag!r}."
+            )
+
+        for proc in members:
+            f = root_dir / f"{proc}_{tag}.root"
+            if f.is_file():
+                existing.append(str(f))
+            else:
+                missing.append(str(f))
+
+        if missing:
+            raise FileNotFoundError(
+                "Some or all files for group "
+                f"{group!r}, era={era!r}, tag={tag!r} are missing.\n"
+                "Missing files:\n"
+                + "\n".join(f"  - {m}" for m in missing)
+            )
+
+    # Clone base loader using all member files
+    return _base.clone_from_files(existing)
+
+# ----------------------------------------------------------------------
+# Module-level __getattr__: lazy instantiation for all samples
+# ----------------------------------------------------------------------
+def __getattr__(name: str):
+    """
+    Lazily construct RDataLoaders on first access.
+
+    Supported patterns:
+
+      - <process>_<era>
+            → uses tag 'nominal'
+        e.g.  TTSemi_pow_2018
+
+      - <process>_<era>_<tag>
+            → uses tag exactly as given
+        e.g.  TTSemi_pow_2018_CMS_res_j_0_2018_down
+              TTSemi_pow_2018_Uncl_up
+
+      - <group>_<era>_<tag>
+            → group of processes defined in GROUPS
+        e.g.  singleTop_2016_nominal
+              DrellYan_2018_nominal
+
+    On disk:
+
+        BASE_DIRECTORY / era / f"{process}_{tag}.root"
+    """
+    # --- NEW: ignore special/dunder attributes like __path__, __all__, etc. ---
+    if name.startswith("__") and name.endswith("__"):
+        # For internal attributes we MUST behave like a normal module
+        # and raise AttributeError, otherwise import/tooling gets upset.
+        raise AttributeError(name)
+
+    # Parse name into process, era, tag
+    # (you can remove your debug print now)
+    try:
+        process, era, tag = _parse_name(name)
+    except ValueError as e:
+        # For module-level __getattr__, ImportError ensures the message is visible
+        # in "from samples_RunII import <name>" failures.
+        raise ImportError(str(e)) from None
+
+    if not tag:
+        tag = "nominal"
+
+    is_group = process in GROUPS
+
+    # Try to build the loader
+    try:
+        if is_group:
+            loader = _make_group_variation(process, era, tag)
+        else:
+            loader = _make_variation(process, era, tag)
+    except FileNotFoundError as e:
+        root_dir = BASE_DIRECTORY / era
+        msg_lines = [
+            f"Could not construct sample {name!r}.",
+            str(e),
+            "",
+        ]
+
+        if is_group:
+            msg_lines.append(f"{process!r} is defined as a group with members:")
+            msg_lines.append("  " + ", ".join(GROUPS[process]))
+            msg_lines.append("")
+            msg_lines.append(
+                f"Each member is expected to have a file "
+                f"'<process>_{tag}.root' in {root_dir}"
+            )
+            msg_lines.append("")
+        elif root_dir.is_dir():
+            available_tags = _available_tags_for(process, era)
+            if available_tags:
+                msg_lines.append(
+                    f"Available variations for process={process!r} in era={era!r} "
+                    f"(i.e. files '{process}_<tag>.root') are:"
+                )
+                msg_lines.append(", ".join(available_tags))
+                msg_lines.append("")
+            else:
+                msg_lines.append(
+                    f"No ROOT files found for process={process!r} in era={era!r}."
+                )
+                era_files = _available_files_for_era(era)
+                if era_files:
+                    msg_lines.append(
+                        f"Some ROOT files available in {root_dir} (era={era!r}) are:"
+                    )
+                    max_show = 30
+                    shown = era_files[:max_show]
+                    msg_lines.append("\n".join(f"  - {f}" for f in shown))
+                    if len(era_files) > max_show:
+                        msg_lines.append(
+                            f"  ... and {len(era_files) - max_show} more."
+                        )
+                    msg_lines.append("")
+
+        syst_tags = SYSTEMATICS.get(era, [])
+        if syst_tags:
+            msg_lines.append(
+                f"Recognised systematic tags for era={era!r} from SYSTEMATICS "
+                "(may or may not exist on disk for this process/group):"
+            )
+            msg_lines.append(", ".join(sorted(syst_tags)))
+            msg_lines.append("")
+
+        raise ImportError("\n".join(msg_lines)) from None
+
+    globals()[name] = loader
+    return loader
+
+# ----------------------------------------------------------------------
+#  A factory class that exposes the base directory
+# ----------------------------------------------------------------------
+class Factory:
+
+    def __init__( self, 
+            BASE_DIRECTORY: str = BASE_DIRECTORY,
+            features: List[str] = None,
+            selection: str = None,
+            selection_features: List[str] = None,
+            ):
+        if type(BASE_DIRECTORY) == str:
+            self.BASE_DIRECTORY = Path(BASE_DIRECTORY)
+        else:
+            self.BASE_DIRECTORY = BASE_DIRECTORY
+
+        self.features = features
+        self.selection = selection
+        self.selection_features = selection_features
+
+    def get(self, process: str, era: str = None, tag: str = None) -> RDataLoader:
+
+        if not era and tag:
+            raise RuntimeError(f"When you specify a tag (here: {tag}) you must specify the era." )
+        
+        if not era:
+            process, era, tag = _parse_name(process)
+            
+        if not tag:
+            tag = "nominal"
+
+        is_group = process in GROUPS
+
+        # Try to build the loader
+        try:
+            if is_group:
+                loader = _make_group_variation(process, era, tag, BASE_DIRECTORY = self.BASE_DIRECTORY)
+            else:
+                loader = _make_variation(process, era, tag, BASE_DIRECTORY = self.BASE_DIRECTORY)
+        except FileNotFoundError as e:
+            root_dir = self.BASE_DIRECTORY / era
+            msg_lines = [
+                f"Could not construct sample {process} {era!r} {tag}.",
+                str(e),
+                "",
+            ]
+
+            if is_group:
+                msg_lines.append(f"{process!r} is defined as a group with members:")
+                msg_lines.append("  " + ", ".join(GROUPS[process]))
+                msg_lines.append("")
+                msg_lines.append(
+                    f"Each member is expected to have a file "
+                    f"'<process>_{tag}.root' in {root_dir}"
+                )
+                msg_lines.append("")
+            elif root_dir.is_dir():
+                available_tags = _available_tags_for(process, era)
+                if available_tags:
+                    msg_lines.append(
+                        f"Available variations for process={process!r} in era={era!r} "
+                        f"(i.e. files '{process}_<tag>.root') are:"
+                    )
+                    msg_lines.append(", ".join(available_tags))
+                    msg_lines.append("")
+                else:
+                    msg_lines.append(
+                        f"No ROOT files found for process={process!r} in era={era!r}."
+                    )
+                    era_files = _available_files_for_era(era)
+                    if era_files:
+                        msg_lines.append(
+                            f"Some ROOT files available in {root_dir} (era={era!r}) are:"
+                        )
+                        max_show = 30
+                        shown = era_files[:max_show]
+                        msg_lines.append("\n".join(f"  - {f}" for f in shown))
+                        if len(era_files) > max_show:
+                            msg_lines.append(
+                                f"  ... and {len(era_files) - max_show} more."
+                            )
+                        msg_lines.append("")
+
+            syst_tags = SYSTEMATICS.get(era, [])
+            if syst_tags:
+                msg_lines.append(
+                    f"Recognised systematic tags for era={era!r} from SYSTEMATICS "
+                    "(may or may not exist on disk for this process/group):"
+                )
+                msg_lines.append(", ".join(sorted(syst_tags)))
+                msg_lines.append("")
+
+            raise e 
+        if self.features:
+            loader.setFeatures( self.features )
+        if self.selection:
+            loader.addSelection( self.selection, required_branches = self.selection_features )
+        return loader
+
+if __name__ == "__main__":
+    #print("Base:", _base)
+    print("Base:", tt2l_delphes)
+    F,O,W = tt2l_delphes.materialize(0,"fow")
+    print("Shapes:", F.shape, O.shape, W.shape)
+

--- a/orth/orthogonalize_Fisher.py
+++ b/orth/orthogonalize_Fisher.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import os, sys, json, math, argparse
 import numpy as np
+import importlib
 
 from tqdm import tqdm
 import matplotlib.pyplot as plt
@@ -73,11 +74,24 @@ print("\n[free] Parameters to probe:")
 for nm in free_names:
     print("   -", nm)
 
+# Make sample loader factory from default cfg
+samples_mod = importlib.import_module(cfg["defaults"]["module_samples"])
+
+from common.yaml_loader import _resolve_features_list
+default_features = cfg["defaults"].get("default_features", None)
+features = _resolve_features_list( default_features ) if default_features else None
+factory     = samples_mod.Factory( 
+    features  = features,
+    selection = cfg["defaults"].get("default_selection", None),
+    selection_features = cfg["defaults"].get("default_selection_features", None),
+    )
+
 # ---- Build caches, prepare runtime ----
 n2ll = N2LLExtensions(
     like_info,
-    cfg['defaults']['module_samples'],
-    os.path.join(
+    # cfg['defaults']['module_samples'],
+    factory = factory,
+    cache_subdir = os.path.join(
         "NN2LCache",
         os.path.splitext(os.path.basename(args.config))[0],
         str(cfg.get("version", "v0")),
@@ -285,7 +299,7 @@ from common import helpers
 import common.user as user
 
 plot_directory = os.path.join(
-    user.plot_directory, args.plot_directory, os.path.splitext(os.path.basename(args.config))[0],
+    user.plot_directory, args.plot_directory, cfg['version'],os.path.splitext(os.path.basename(args.config))[0],
 )
 os.makedirs(plot_directory, exist_ok=True)
 
@@ -324,7 +338,7 @@ for R in n2ll.regions:
     region_feats, region_w0s = [], []
     feature_names_ref = None
     for sname in asimov_list:
-        L = getattr(n2ll.samples_mod, sname)
+        L = n2ll.factory.get(sname)
         feat_names = list(getattr(L, "feature_names", []) or [])
         if feature_names_ref is None: feature_names_ref = feat_names
         elif feat_names != feature_names_ref:

--- a/orth/orthogonalize_Fisher.py
+++ b/orth/orthogonalize_Fisher.py
@@ -93,8 +93,8 @@ n2ll = N2LLExtensions(
     factory = factory,
     cache_subdir = os.path.join(
         "NN2LCache",
-        os.path.splitext(os.path.basename(args.config))[0],
         str(cfg.get("version", "v0")),
+        os.path.splitext(os.path.basename(args.config))[0],
     ),
     cache_root=args.cache_root,
     overwrite=args.overwrite,


### PR DESCRIPTION
Adding the configs for the new basis for all eras, fitting from 1 to 9 elements in the new basis.

Following our defined convention
- v5 (for paper): new basis, Total JES uncertainty with Eta split 
- v5_CMSJES: new basis, CMS JES model (for future analysis)

Will keep this as draft until we actually ran the orthogonalization+fits.