### PR TITLE
Likelihood.py: removing coarse fixed precision

### DIFF
--- a/fit/Likelihood.py
+++ b/fit/Likelihood.py
@@ -1871,8 +1871,6 @@ def run_minuit_fit(n2ll, hypothesis, *, step=None, print_every=25,
         for i, nm in enumerate(names):
             print(f"  - {nm:>16s}  start = {m.values[i]: .6e}  step = {m.errors[i]: .3g}")
 
-    m.precision = 0.001
-    print(f"Minuit precision: {m.precision}") 
     if do_migrad:
         m.migrad();
         if verbosity >= 1:


### PR DESCRIPTION
Removing coarse fixed Minuit precision, as it was leading to numerically coarse (wrong) calculations for the derivatives and affecting fit convergence and uncertainty estimates in data fits. See example here (blue - double precision, orange - 0.001 precision):
https://ricardobarrue.web.cern.ch/SBIPDF/minuitprecision_None_v_0p001/fit_comparison_all.png

Now, it calculates N2LL at double precision (Minuit default).