### PR TITLE
Add configurable TFMC zero-init jobs

### DIFF
--- a/ML/TFMC/TFMC.py
+++ b/ML/TFMC/TFMC.py
@@ -74,7 +74,18 @@ class TFMC:
             m.add(layers.Dense(units, activation=self.activation, kernel_regularizer=reg))
             if self.dropout_rate and self.dropout_rate > 0:
                 m.add(layers.Dropout(self.dropout_rate))
-        m.add(layers.Dense(self.num_classes, activation="softmax", kernel_regularizer=reg))
+        # Start from equal class logits so the initial softmax is flat.
+        # With the existing DCR conversion (divide by class_weights, then renormalize),
+        # this makes the epoch-0 inclusive fractions reflect the class-weight sums.
+        m.add(
+            layers.Dense(
+                self.num_classes,
+                activation="softmax",
+                kernel_regularizer=reg,
+                kernel_initializer=initializers.Zeros(),
+                bias_initializer=initializers.Zeros(),
+            )
+        )
         return m
 
     # ---------------- scalers / IC ----------------
@@ -232,4 +243,3 @@ class TFMC:
         inst.class_weights = np.asarray(meta["class_weights"])
         inst.checkpoint.restore(latest).expect_partial()
         return inst
-

--- a/ML/TFMC/TFMC.py
+++ b/ML/TFMC/TFMC.py
@@ -32,6 +32,7 @@ class TFMC:
         classes: list[str],
         activation: str = "relu",
         hidden_layers: list[int] = (64, 64, 64),
+        zero_init: bool = False,
         l1_reg: float = 0.0,
         l2_reg: float = 0.0,
         dropout_rate: float = 0.0,
@@ -45,6 +46,7 @@ class TFMC:
         self.num_classes = len(self.classes)
         self.activation = activation
         self.hidden_layers = list(hidden_layers)
+        self.zero_init = bool(zero_init)
         self.l1_reg = float(l1_reg)
         self.l2_reg = float(l2_reg)
         self.dropout_rate = float(dropout_rate)
@@ -74,18 +76,21 @@ class TFMC:
             m.add(layers.Dense(units, activation=self.activation, kernel_regularizer=reg))
             if self.dropout_rate and self.dropout_rate > 0:
                 m.add(layers.Dropout(self.dropout_rate))
-        # Start from equal class logits so the initial softmax is flat.
-        # With the existing DCR conversion (divide by class_weights, then renormalize),
-        # this makes the epoch-0 inclusive fractions reflect the class-weight sums.
-        m.add(
-            layers.Dense(
-                self.num_classes,
-                activation="softmax",
-                kernel_regularizer=reg,
-                kernel_initializer=initializers.Zeros(),
-                bias_initializer=initializers.Zeros(),
+        if self.zero_init:
+            # Start from equal class logits so the initial softmax is flat.
+            # With the existing DCR conversion (divide by class_weights, then renormalize),
+            # this makes the epoch-0 inclusive fractions reflect the class-weight sums.
+            m.add(
+                layers.Dense(
+                    self.num_classes,
+                    activation="softmax",
+                    kernel_regularizer=reg,
+                    kernel_initializer=initializers.Zeros(),
+                    bias_initializer=initializers.Zeros(),
+                )
             )
-        )
+        else:
+            m.add(layers.Dense(self.num_classes, activation="softmax", kernel_regularizer=reg))
         return m
 
     # ---------------- scalers / IC ----------------

--- a/ML/TFMC/tfmc_training.py
+++ b/ML/TFMC/tfmc_training.py
@@ -518,8 +518,8 @@ best_val = float("inf") if mode == "min" else -float("inf")
 best_epoch = -1
 bad_epochs = 0
 
-# resume historical BEST if exists, so continuing training keeps the old best
-if os.path.exists(best_txt):
+# resume historical BEST only when continuing an existing training
+if not args.overwrite and os.path.exists(best_txt):
     try:
         with open(best_txt, "r") as f:
             line = f.read().strip()
@@ -628,8 +628,7 @@ for epoch in trange(start_epoch, epochs, desc="Epoch", position=0):
                 # gives the state of the network at initialization
                 if do_plot:
                     values_tr  = model.predict(Xb_tr,  probability=args.plot_probability)
-                    ones_tr    = np.ones_like(wb_tr,  dtype=np.float32)
-                    accumulate_histograms(true_h_tr,  pred_h_tr,  bins, Xb_tr,  yb_tr,  values_tr,  ones_tr,  plot_feats, feat2col)
+                    accumulate_histograms(true_h_tr,  pred_h_tr,  bins, Xb_tr,  yb_tr,  values_tr,  wb_tr,  plot_feats, feat2col)
 
                 loss_train = model.train_on_batch(Xb_tr, yb_tr, wb_tr)
                 losses_train.append(loss_train)
@@ -645,8 +644,7 @@ for epoch in trange(start_epoch, epochs, desc="Epoch", position=0):
                 # but matches what's on the validation loss curves (after update)
                 if do_plot:
                     values_val = model.predict(Xb_val, probability=args.plot_probability)
-                    ones_val   = np.ones_like(wb_val, dtype=np.float32)
-                    accumulate_histograms(true_h_val, pred_h_val, bins, Xb_val, yb_val, values_val, ones_val, plot_feats, feat2col)
+                    accumulate_histograms(true_h_val, pred_h_val, bins, Xb_val, yb_val, values_val, wb_val, plot_feats, feat2col)
 
                 pbar.set_postfix(loss=float(loss_train))
                 pbar.update(1)

--- a/ML/TFMC/tfmc_training.py
+++ b/ML/TFMC/tfmc_training.py
@@ -76,6 +76,7 @@ J = job  # shorthand
 classes_names = list(J["data"]["classes"])
 activation = J["model"].get("activation", "relu")
 hidden_layers = J["model"].get("hidden_layers", [64,64,64])
+zero_init = bool(J["model"].get("zero_init", False))
 dropout_rate = float(J["model"].get("dropout_rate", 0.0))
 l1 = float(J["model"].get("l1", 0.0))
 l2 = float(J["model"].get("l2", 0.0))
@@ -461,6 +462,7 @@ if model is None:
         classes=classes_names,
         activation=activation,
         hidden_layers=hidden_layers,
+        zero_init=zero_init,
         l1_reg=l1,
         l2_reg=l2,
         dropout_rate=dropout_rate,

--- a/configs/unbinned_v6_rate/unbinned_2016APV_rate.yaml
+++ b/configs/unbinned_v6_rate/unbinned_2016APV_rate.yaml
@@ -201,14 +201,35 @@ jobs:
       hidden_layers: [64, 64]
     optim:
       epochs: 1000
-      phaseout_epochs: 0
-      learning_rate: 0.0002
+      phaseout_epochs: 50
+      learning_rate: 0.001
     runtime:
       batch_size: -1 # batch = shard (= 1 by default)
     extras:
       use_scaler: scaler_TTLep_pow_2016APV
     output:
       filename: "tfmc_2016APV.pkl"
+
+  - id: tfmc_2016APV_zero_init
+    type: classifier
+    region: SR_2016APV
+    framework: "tfmc"
+    data:
+      classes: [TTLep_pow_2016APV, SingleTop_2016APV, DrellYan_2016APV, TTSemi_pow_2016APV]
+    model:
+      activation: relu
+      hidden_layers: [64, 64]
+      zero_init: true
+    optim:
+      epochs: 1000
+      phaseout_epochs: 50
+      learning_rate: 0.001
+    runtime:
+      batch_size: -1 # batch = shard (= 1 by default)
+    extras:
+      use_scaler: scaler_TTLep_pow_2016APV
+    output:
+      filename: "tfmc_2016APV_zero_init.pkl"
 
   # combining backgrounds into total bkg component to assist in training
   - id: tfmc_2016APV_totalbkg


### PR DESCRIPTION
## Summary
- add a configurable `zero_init` option to TFMC model construction
- keep the default behavior unchanged unless the YAML enables the flag
- add a dedicated `tfmc_2016APV_zero_init` job and update both 2016APV TFMC jobs to use the higher learning rate with phaseout
- keep weighted convergence plotting and clean `--overwrite` best-checkpoint handling in the TFMC training path

## Testing
- `python3 -m py_compile ML/TFMC/tfmc_training.py ML/TFMC/TFMC.py`
- short `--small` debug runs for the baseline and zero-init TFMC jobs