### PR TITLE
Systematics in for EFT samples: updates to loader + configs (#134)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,9 +175,10 @@ cheap to fix; complex and wrong has to be understood before it can be fixed.
 - Don't use shorthand naming for variables that are not auxiliary variables. Be verbose but no more than three words.
 - Use ascii characters only, and e.g. write lambda explicitly instead of the lambda character.
 - Don't give a random name to plan files. The plan file name should be a shorthand for what is being implemented.
-- Plans live in `user/<name>/claude/`.
+- Plans live in `user/<name>/claude/`. These will be executed in Auto mode, so plan accordingly.
 - Keep rejected alternatives and their rationale in a separate `*-design-decisions.md` alongside the plan: the plan goes stale once implemented, the decision record does not, and the implementer doesn't need it.
-- When developing code, use worktrees, putting each individual new functionality or change to pieces of individual functionality into separate commits.
+- When developing code, check if we are in an existing worktree. If not, create a new one.
+- When developing code, put each individual new functionality or change to pieces of individual functionality into separate commits.
 
 ## Non-obvious design decisions
 

--- a/ML/ICP/icp_training.py
+++ b/ML/ICP/icp_training.py
@@ -34,9 +34,9 @@ if args.job is None:
     if not jobs:
         print("No ICP jobs found in YAML.")
         sys.exit(0)
-    script = os.path.basename(__file__)
+    #script = os.path.basename(__file__)
     for j in jobs:
-        print(f"python {script} {args.config} --job {j['id']}".strip())
+        print(f"python {__file__} {args.config} --job {j['id']}".strip())
     sys.exit(0)
 
 # ---------------- resolve job ----------------

--- a/ML/PNN/pnn_training.py
+++ b/ML/PNN/pnn_training.py
@@ -45,7 +45,7 @@ def list_and_exit():
     if args.small:     flags.append("--small")
     script = os.path.basename(__file__)
     for j in jobs:
-        print(f"python {script} {args.config} {' '.join(flags)} --job {j['id']}")
+        print(f"python {__file__} {args.config} {' '.join(flags)} --job {j['id']}")
     sys.exit(0)
 
 if args.job is None:

--- a/configs/unbinned_v7_eft/unbinned_2016APV_eft.yaml
+++ b/configs/unbinned_v7_eft/unbinned_2016APV_eft.yaml
@@ -48,16 +48,16 @@ defaults:
 
 likelihood:
     regions:
-        - id: SR_2016 
+        - id: SR_2016APV 
           classifier:
             type: null
             id: null    # no classifier needed for a single process
-            asimov: [TT01j2l_EFT_2016]
+            asimov: [TT01j2l_EFT_2016APV]
           classes: 
-            - id: TT01j2l_EFT_2016
-              sample: TT01j2l_EFT_2016 
+            - id: TT01j2l_EFT_2016APV
+              sample: TT01j2l_EFT_2016APV 
               POI:
-                job: bit_TT01j2l_EFT_2016_ctG 
+                job: bit_TT01j2l_EFT_2016APV_ctG 
                 type: bit
                 parameters: [ctGRe, ctGIm]
 
@@ -76,136 +76,136 @@ likelihood:
                   parameters: [nu_lumi_15161718]                      
                 - id: L1Prefire
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_L1Prefire
+                  job: pnn_TT01j2l_EFT_2016APV_L1Prefire
                   parameters: [nu_l1prefire]
                 - id: PU
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_PU
+                  job: pnn_TT01j2l_EFT_2016APV_PU
                   parameters: [nu_pu]
                 - id: MuSF 
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_MuSF
+                  job: pnn_TT01j2l_EFT_2016APV_MuSF
                   parameters: [nu_MuSF]
                 - id: EleSF
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_EleSF
+                  job: pnn_TT01j2l_EFT_2016APV_EleSF
                   parameters: [nu_EleSF]
                 - id: BTag_b
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_BTag_b
+                  job: pnn_TT01j2l_EFT_2016APV_BTag_b
                   parameters: [nu_btag_b]
                 - id: BTag_l
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_BTag_l
+                  job: pnn_TT01j2l_EFT_2016APV_BTag_l
                   parameters: [nu_btag_l]
                 - id: Scales
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_scales
+                  job: pnn_TT01j2l_EFT_2016APV_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
                 - id: ShowerISR
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_showerISR
+                  job: pnn_TT01j2l_EFT_2016APV_showerISR
                   parameters: [nu_showerISR]
                 - id: ShowerFSR
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_showerFSR
+                  job: pnn_TT01j2l_EFT_2016APV_showerFSR
                   parameters: [nu_showerFSR]
                 - id: AlphaS
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_alphaS
+                  job: pnn_TT01j2l_EFT_2016APV_alphaS
                   parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_res_j_0_2016
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_res_j_0_2016APV
                   parameters: [nu_CMS_res_j_0]
                 - id: CMS_res_j_1
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_res_j_1_2016
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_res_j_1_2016APV
                   parameters: [nu_CMS_res_j_1]
                 - id: CMS_res_j_2
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_res_j_2_2016
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_res_j_2_2016APV
                   parameters: [nu_CMS_res_j_2]
                 - id: CMS_res_j_3
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_res_j_3_2016
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_res_j_3_2016APV
                   parameters: [nu_CMS_res_j_3]
                 - id: CMS_res_j_4
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_res_j_4_2016
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_res_j_4_2016APV
                   parameters: [nu_CMS_res_j_4]
                 - id: CMS_res_j_5
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_res_j_5_2016
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_res_j_5_2016APV
                   parameters: [nu_CMS_res_j_5]
                 - id: CMS_scale_j_FlavorPureBottom
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureBottom
                   parameters: [nu_CMS_scale_j_FlavorPureBottom]
                 - id: CMS_scale_j_FlavorPureCharm
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureCharm
                   parameters: [nu_CMS_scale_j_FlavorPureCharm]
                 - id: CMS_scale_j_FlavorPureGluon
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureGluon
                   parameters: [nu_CMS_scale_j_FlavorPureGluon]
                 - id: CMS_scale_j_FlavorPureQuark
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureQuark
                   parameters: [nu_CMS_scale_j_FlavorPureQuark]
                 - id: CMS_scale_j_Regrouped_Absolute_2016
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute_2016
                   parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
                 - id: CMS_scale_j_Regrouped_Absolute
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute
                   parameters: [nu_CMS_scale_j_Regrouped_Absolute]
                 - id: CMS_scale_j_Regrouped_BBEC1_2016
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
                   parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
                 - id: CMS_scale_j_Regrouped_BBEC1
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1
                   parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
                 - id: CMS_scale_j_Regrouped_EC2_2016
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2_2016
                   parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
                 - id: CMS_scale_j_Regrouped_EC2
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2
                   parameters: [nu_CMS_scale_j_Regrouped_EC2]
                 - id: CMS_scale_j_Regrouped_HF_2016
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF_2016
                   parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
                 - id: CMS_scale_j_Regrouped_HF
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF
                   parameters: [nu_CMS_scale_j_Regrouped_HF]
                 - id: CMS_scale_j_Regrouped_RelativeBal
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeBal
                   parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
                 - id: CMS_scale_j_Regrouped_RelativeSample_2016
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+                  job: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
                   parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
                 - id: Uncl
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_Uncl
+                  job: pnn_TT01j2l_EFT_2016APV_Uncl
                   parameters: [nu_Uncl]
 
 
 jobs:
 
-  - id: bit_TT01j2l_EFT_2016_ctG
+  - id: bit_TT01j2l_EFT_2016APV_ctG
     type: bit
-    region: SR_2016
-    process: TT01j2l_EFT_2016
+    region: SR_2016APV
+    process: TT01j2l_EFT_2016APV
     numba: True
     eft: 
         parameters: [ctGRe, ctGIm]
@@ -220,52 +220,52 @@ jobs:
     runtime:
       training_plots: true
     output:
-      filename: "bit_TT01j2l_EFT_2016_ctG.pkl"
+      filename: "bit_TT01j2l_EFT_2016APV_ctG.pkl"
 
-  - id: scaler_TT01j2l_EFT_2016
+  - id: scaler_TT01j2l_EFT_2016APV
     type: scaler
-    process: TT01j2l_EFT_2016
-    region: SR_2016
+    process: TT01j2l_EFT_2016APV
+    region: SR_2016APV
     selection: null
     output:
-      filename: "Scaler_TT01j2l_EFT_2016.pkl"
+      filename: "Scaler_TT01j2l_EFT_2016APV.pkl"
 
-  - id: icp_TT01j2l_EFT_2016_L1Prefire
+  - id: icp_TT01j2l_EFT_2016APV_L1Prefire
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_l1prefire]
     combinations: [[nu_l1prefire]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["L1PreFiringWeight_Nom"]
       addweights: ["L1PreFiringWeight_Dn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["L1PreFiringWeight_Nom"]
       addweights: ["L1PreFiringWeight_Up"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_L1Prefire.pkl
+      filename: icp_TT01j2l_EFT_2016APV_L1Prefire.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_L1Prefire
+  - id: pnn_TT01j2l_EFT_2016APV_L1Prefire
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_l1prefire]
     combinations: [[nu_l1prefire]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["L1PreFiringWeight_Nom"]
       addweights: ["L1PreFiringWeight_Dn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["L1PreFiringWeight_Nom"]
       addweights: ["L1PreFiringWeight_Up"]
     model:
@@ -282,45 +282,45 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_L1Prefire
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_L1Prefire
 
-  - id: icp_TT01j2l_EFT_2016_PU
+  - id: icp_TT01j2l_EFT_2016APV_PU
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_pu]
     combinations: [[nu_pu]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["Pileup_SF"]
       addweights: ["Pileup_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["Pileup_SF"]
       addweights: ["Pileup_SFUp"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_PU.pkl
+      filename: icp_TT01j2l_EFT_2016APV_PU.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_PU
+  - id: pnn_TT01j2l_EFT_2016APV_PU
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_pu]
     combinations: [[nu_pu]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["Pileup_SF"]
       addweights: ["Pileup_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["Pileup_SF"]
       addweights: ["Pileup_SFUp"]
     model:
@@ -337,45 +337,45 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_PU
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_PU
 
-  - id: icp_TT01j2l_EFT_2016_MuSF
+  - id: icp_TT01j2l_EFT_2016APV_MuSF
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_MuSF]
     combinations: [[nu_MuSF]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["lepMu_SF"]
       addweights: ["lepMu_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["lepMu_SF"]
       addweights: ["lepMu_SFUp"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_MuSF.pkl
+      filename: icp_TT01j2l_EFT_2016APV_MuSF.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_MuSF
+  - id: pnn_TT01j2l_EFT_2016APV_MuSF
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_MuSF]
     combinations: [[nu_MuSF]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["lepMu_SF"]
       addweights: ["lepMu_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["lepMu_SF"]
       addweights: ["lepMu_SFUp"]
     model:
@@ -392,45 +392,45 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_MuSF
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_MuSF
 
-  - id: icp_TT01j2l_EFT_2016_EleSF
+  - id: icp_TT01j2l_EFT_2016APV_EleSF
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_EleSF]
     combinations: [[nu_EleSF]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["lepEle_SF"]
       addweights: ["lepEle_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["lepEle_SF"]
       addweights: ["lepEle_SFUp"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_EleSF.pkl
+      filename: icp_TT01j2l_EFT_2016APV_EleSF.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_EleSF
+  - id: pnn_TT01j2l_EFT_2016APV_EleSF
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_EleSF]
     combinations: [[nu_EleSF]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["lepEle_SF"]
       addweights: ["lepEle_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["lepEle_SF"]
       addweights: ["lepEle_SFUp"]
     model:
@@ -447,45 +447,45 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_EleSF
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_EleSF
 
-  - id: icp_TT01j2l_EFT_2016_BTag_b
+  - id: icp_TT01j2l_EFT_2016APV_BTag_b
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_btag_b]
     combinations: [[nu_btag_b]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_BTag_b.pkl
+      filename: icp_TT01j2l_EFT_2016APV_BTag_b.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_BTag_b
+  - id: pnn_TT01j2l_EFT_2016APV_BTag_b
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_btag_b]
     combinations: [[nu_btag_b]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
     model:
@@ -502,44 +502,44 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_BTag_b
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_BTag_b
 
-  - id: icp_TT01j2l_EFT_2016_BTag_l
+  - id: icp_TT01j2l_EFT_2016APV_BTag_l
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_btag_l]
     combinations: [[nu_btag_l]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_BTag_l.pkl
-  - id: pnn_TT01j2l_EFT_2016_BTag_l
+      filename: icp_TT01j2l_EFT_2016APV_BTag_l.pkl
+  - id: pnn_TT01j2l_EFT_2016APV_BTag_l
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_btag_l]
     combinations: [[nu_btag_l]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
     model:
@@ -556,82 +556,82 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_BTag_l
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_BTag_l
 
-  - id: icp_TT01j2l_EFT_2016_scales
+  - id: icp_TT01j2l_EFT_2016APV_scales
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_mu_ren, nu_mu_fac]
     combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
           nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
     base_points:
     - coords: [-1.0, -1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren0p5_fac0p5"]
     - coords: [-1.0, 0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren0p5_fac1p0"]
     - coords: [-1.0, 1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren0p5_fac2p0"]
     - coords: [0, -1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren1p0_fac0p5"]
     - coords: [0, 0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren1p0_fac1p0"]
       nominal: true
     - coords: [0, 1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren1p0_fac2p0"]
     - coords: [1.0, -1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren2p0_fac0p5"]
     - coords: [1.0, 0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren2p0_fac1p0"]
     - coords: [1.0, 1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren2p0_fac2p0"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_scales.pkl
+      filename: icp_TT01j2l_EFT_2016APV_scales.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_scales
+  - id: pnn_TT01j2l_EFT_2016APV_scales
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_mu_ren, nu_mu_fac]
     combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
           nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
     base_points:
     - coords: [-1.0, -1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren0p5_fac0p5"]
     - coords: [-1.0, 0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren0p5_fac1p0"]
     - coords: [-1.0, 1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren0p5_fac2p0"]
     - coords: [0, -1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren1p0_fac0p5"]
     - coords: [0, 0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren1p0_fac1p0"]
       nominal: true
     - coords: [0, 1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren1p0_fac2p0"]
     - coords: [1.0, -1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren2p0_fac0p5"]
     - coords: [1.0, 0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren2p0_fac1p0"]
     - coords: [1.0, 1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       addweights: ["scale_ren2p0_fac2p0"]
     model:
       hidden_layers:
@@ -647,42 +647,42 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_scales
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_scales
 
-  - id: icp_TT01j2l_EFT_2016_showerISR
+  - id: icp_TT01j2l_EFT_2016APV_showerISR
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_showerISR]
     combinations: [[nu_showerISR]]
     base_points:
       - coords: [-1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         addweights: ["shower_isr0p5_fsr1p0"]
       - coords: [0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         nominal: true
       - coords: [1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         addweights: ["shower_isr2p0_fsr1p0"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_showerISR.pkl
+      filename: icp_TT01j2l_EFT_2016APV_showerISR.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_showerISR
+  - id: pnn_TT01j2l_EFT_2016APV_showerISR
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_showerISR]
     combinations: [[nu_showerISR]]
     base_points:
       - coords: [-1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         addweights: ["shower_isr0p5_fsr1p0"]
       - coords: [0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         nominal: true
       - coords: [1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         addweights: ["shower_isr2p0_fsr1p0"]
     model:
       hidden_layers:
@@ -698,42 +698,42 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_showerISR
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_showerISR
 
-  - id: icp_TT01j2l_EFT_2016_showerFSR
+  - id: icp_TT01j2l_EFT_2016APV_showerFSR
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_showerFSR]
     combinations: [[nu_showerFSR]]
     base_points:
       - coords: [-1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         addweights: ["shower_isr1p0_fsr0p5"]
       - coords: [0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         nominal: true
       - coords: [1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         addweights: ["shower_isr1p0_fsr2p0"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_showerFSR.pkl
+      filename: icp_TT01j2l_EFT_2016APV_showerFSR.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_showerFSR
+  - id: pnn_TT01j2l_EFT_2016APV_showerFSR
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_showerFSR]
     combinations: [[nu_showerFSR]]
     base_points:
       - coords: [-1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         addweights: ["shower_isr1p0_fsr0p5"]
       - coords: [0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         nominal: true
       - coords: [1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         addweights: ["shower_isr1p0_fsr2p0"]
     model:
       hidden_layers:
@@ -749,42 +749,42 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_showerFSR
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_showerFSR
 
-  - id: icp_TT01j2l_EFT_2016_alphaS
+  - id: icp_TT01j2l_EFT_2016APV_alphaS
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_alphaS]
     combinations: [[nu_alphaS]]
     base_points:
       - coords: [-1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         addweights: ["pdf_alphas_dn"]
       - coords: [0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         nominal: true
       - coords: [1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         addweights: ["pdf_alphas_up"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_alphaS.pkl
+      filename: icp_TT01j2l_EFT_2016APV_alphaS.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_alphaS
+  - id: pnn_TT01j2l_EFT_2016APV_alphaS
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_alphaS]
     combinations: [[nu_alphaS]]
     base_points:
       - coords: [-1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         addweights: ["pdf_alphas_dn"]
       - coords: [0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         nominal: true
       - coords: [1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2016APV
         addweights: ["pdf_alphas_up"]
     model:
       hidden_layers:
@@ -800,39 +800,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_alphaS
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_alphaS
 
-  - id: icp_TT01j2l_EFT_2016_CMS_res_j_0_2016
+  - id: icp_TT01j2l_EFT_2016APV_CMS_res_j_0_2016APV
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_0]
     combinations: [[nu_CMS_res_j_0]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_0_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_0_2016APV_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_0_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_0_2016APV_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_res_j_0_2016.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_res_j_0_2016APV.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_res_j_0_2016
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_res_j_0_2016APV
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_0]
     combinations: [[nu_CMS_res_j_0]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_0_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_0_2016APV_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_0_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_0_2016APV_up
     model:
       hidden_layers:
       - 128
@@ -847,39 +847,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_res_j_0_2016
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_res_j_0_2016APV
 
-  - id: icp_TT01j2l_EFT_2016_CMS_res_j_1_2016
+  - id: icp_TT01j2l_EFT_2016APV_CMS_res_j_1_2016APV
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_1]
     combinations: [[nu_CMS_res_j_1]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_1_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_1_2016APV_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_1_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_1_2016APV_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_res_j_1_2016.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_res_j_1_2016APV.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_res_j_1_2016
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_res_j_1_2016APV
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_1]
     combinations: [[nu_CMS_res_j_1]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_1_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_1_2016APV_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_1_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_1_2016APV_up
     model:
       hidden_layers:
       - 128
@@ -894,39 +894,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_res_j_1_2016
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_res_j_1_2016APV
 
-  - id: icp_TT01j2l_EFT_2016_CMS_res_j_2_2016
+  - id: icp_TT01j2l_EFT_2016APV_CMS_res_j_2_2016APV
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_2]
     combinations: [[nu_CMS_res_j_2]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_2_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_2_2016APV_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_2_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_2_2016APV_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_res_j_2_2016.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_res_j_2_2016APV.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_res_j_2_2016
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_res_j_2_2016APV
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_2]
     combinations: [[nu_CMS_res_j_2]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_2_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_2_2016APV_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_2_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_2_2016APV_up
     model:
       hidden_layers:
       - 128
@@ -941,39 +941,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_res_j_2_2016
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_res_j_2_2016APV
 
-  - id: icp_TT01j2l_EFT_2016_CMS_res_j_3_2016
+  - id: icp_TT01j2l_EFT_2016APV_CMS_res_j_3_2016APV
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_3]
     combinations: [[nu_CMS_res_j_3]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_3_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_3_2016APV_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_3_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_3_2016APV_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_res_j_3_2016.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_res_j_3_2016APV.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_res_j_3_2016
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_res_j_3_2016APV
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_3]
     combinations: [[nu_CMS_res_j_3]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_3_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_3_2016APV_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_3_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_3_2016APV_up
     model:
       hidden_layers:
       - 128
@@ -988,39 +988,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_res_j_3_2016
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_res_j_3_2016APV
 
-  - id: icp_TT01j2l_EFT_2016_CMS_res_j_4_2016
+  - id: icp_TT01j2l_EFT_2016APV_CMS_res_j_4_2016APV
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_4]
     combinations: [[nu_CMS_res_j_4]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_4_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_4_2016APV_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_4_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_4_2016APV_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_res_j_4_2016.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_res_j_4_2016APV.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_res_j_4_2016
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_res_j_4_2016APV
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_4]
     combinations: [[nu_CMS_res_j_4]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_4_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_4_2016APV_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_4_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_4_2016APV_up
     model:
       hidden_layers:
       - 128
@@ -1035,39 +1035,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_res_j_4_2016
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_res_j_4_2016APV
 
-  - id: icp_TT01j2l_EFT_2016_CMS_res_j_5_2016
+  - id: icp_TT01j2l_EFT_2016APV_CMS_res_j_5_2016APV
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_5]
     combinations: [[nu_CMS_res_j_5]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_5_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_5_2016APV_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_5_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_5_2016APV_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_res_j_5_2016.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_res_j_5_2016APV.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_res_j_5_2016
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_res_j_5_2016APV
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_res_j_5]
     combinations: [[nu_CMS_res_j_5]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_5_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_5_2016APV_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_5_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_res_j_5_2016APV_up
     model:
       hidden_layers:
       - 128
@@ -1082,40 +1082,40 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_res_j_5_2016
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_res_j_5_2016APV
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom
+  - id: icp_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureBottom
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_FlavorPureBottom]
     combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureBottom_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureBottom_up
   
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureBottom.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureBottom
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_FlavorPureBottom]
     combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureBottom_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureBottom_up
   
     model:
       hidden_layers:
@@ -1131,39 +1131,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureBottom
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm
+  - id: icp_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureCharm
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_FlavorPureCharm]
     combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureCharm_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureCharm_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureCharm.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureCharm
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_FlavorPureCharm]
     combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureCharm_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureCharm_up
     model:
       hidden_layers:
       - 128
@@ -1178,39 +1178,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureCharm
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon
+  - id: icp_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureGluon
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_FlavorPureGluon]
     combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureGluon_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureGluon_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureGluon.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureGluon
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_FlavorPureGluon]
     combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureGluon_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureGluon_up
     model:
       hidden_layers:
       - 128
@@ -1225,39 +1225,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureGluon
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark
+  - id: icp_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureQuark
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_FlavorPureQuark]
     combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureQuark_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureQuark_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureQuark.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureQuark
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_FlavorPureQuark]
     combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureQuark_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureQuark_up
     model:
       hidden_layers:
       - 128
@@ -1272,39 +1272,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_scale_j_FlavorPureQuark
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute_2016
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute_2016.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute_2016
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute_2016_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute_2016_up
     model:
       hidden_layers:
       - 128
@@ -1319,40 +1319,40 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute_2016
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_Absolute]
     combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute_up
   
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_Absolute]
     combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute_up
   
     model:
       hidden_layers:
@@ -1368,39 +1368,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_Absolute
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1_2016.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1_2016_up
     model:
       hidden_layers:
       - 128
@@ -1415,39 +1415,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1_2016
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
     combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
     combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1_up
     model:
       hidden_layers:
       - 128
@@ -1462,39 +1462,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_BBEC1
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2_2016
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2_2016.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2_2016
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2_2016_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2_2016_up
     model:
       hidden_layers:
       - 128
@@ -1509,39 +1509,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2_2016
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2
+  - id: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_EC2]
     combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_EC2]
     combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2_up
     model:
       hidden_layers:
       - 128
@@ -1556,39 +1556,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_EC2
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF_2016
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF_2016_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF_2016_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF_2016.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF_2016
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF_2016_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF_2016_up
     model:
       hidden_layers:
       - 128
@@ -1603,39 +1603,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF_2016
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF
+  - id: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_HF]
     combinations: [[nu_CMS_scale_j_Regrouped_HF]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_HF]
     combinations: [[nu_CMS_scale_j_Regrouped_HF]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF_up
     model:
       hidden_layers:
       - 128
@@ -1650,39 +1650,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_HF
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeBal
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
     combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeBal.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeBal
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
     combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeBal_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeBal_up
     model:
       hidden_layers:
       - 128
@@ -1697,39 +1697,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeBal
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+      filename: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: pnn_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
     combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+      loader: TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016_up
     model:
       hidden_layers:
       - 128
@@ -1744,39 +1744,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_CMS_scale_j_Regrouped_RelativeSample_2016
       
-  - id: icp_TT01j2l_EFT_2016_Uncl
+  - id: icp_TT01j2l_EFT_2016APV_Uncl
     type: icp
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_Uncl]
     combinations: [[nu_Uncl]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_Uncl_down
+      loader: TT01j2l_EFT_2016APV_Uncl_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_Uncl_up
+      loader: TT01j2l_EFT_2016APV_Uncl_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_Uncl.pkl
+      filename: icp_TT01j2l_EFT_2016APV_Uncl.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_Uncl
+  - id: pnn_TT01j2l_EFT_2016APV_Uncl
     type: pnn
-    region: SR_2016
+    region: SR_2016APV
     parameters: [nu_Uncl]
     combinations: [[nu_Uncl]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_Uncl_down
+      loader: TT01j2l_EFT_2016APV_Uncl_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2016APV
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_Uncl_up
+      loader: TT01j2l_EFT_2016APV_Uncl_up
     model:
       hidden_layers:
       - 128
@@ -1791,5 +1791,5 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_Uncl
+      use_scaler: scaler_TT01j2l_EFT_2016APV
+      use_icp: icp_TT01j2l_EFT_2016APV_Uncl

--- a/configs/unbinned_v7_eft/unbinned_2018_eft.yaml
+++ b/configs/unbinned_v7_eft/unbinned_2018_eft.yaml
@@ -48,16 +48,16 @@ defaults:
 
 likelihood:
     regions:
-        - id: SR_2016 
+        - id: SR_2018 
           classifier:
             type: null
             id: null    # no classifier needed for a single process
-            asimov: [TT01j2l_EFT_2016]
+            asimov: [TT01j2l_EFT_2018]
           classes: 
-            - id: TT01j2l_EFT_2016
-              sample: TT01j2l_EFT_2016 
+            - id: TT01j2l_EFT_2018
+              sample: TT01j2l_EFT_2018 
               POI:
-                job: bit_TT01j2l_EFT_2016_ctG 
+                job: bit_TT01j2l_EFT_2018_ctG 
                 type: bit
                 parameters: [ctGRe, ctGIm]
 
@@ -76,136 +76,136 @@ likelihood:
                   parameters: [nu_lumi_15161718]                      
                 - id: L1Prefire
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_L1Prefire
+                  job: pnn_TT01j2l_EFT_2018_L1Prefire
                   parameters: [nu_l1prefire]
                 - id: PU
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_PU
+                  job: pnn_TT01j2l_EFT_2018_PU
                   parameters: [nu_pu]
                 - id: MuSF 
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_MuSF
+                  job: pnn_TT01j2l_EFT_2018_MuSF
                   parameters: [nu_MuSF]
                 - id: EleSF
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_EleSF
+                  job: pnn_TT01j2l_EFT_2018_EleSF
                   parameters: [nu_EleSF]
                 - id: BTag_b
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_BTag_b
+                  job: pnn_TT01j2l_EFT_2018_BTag_b
                   parameters: [nu_btag_b]
                 - id: BTag_l
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_BTag_l
+                  job: pnn_TT01j2l_EFT_2018_BTag_l
                   parameters: [nu_btag_l]
                 - id: Scales
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_scales
+                  job: pnn_TT01j2l_EFT_2018_scales
                   parameters: [nu_mu_ren, nu_mu_fac]
                 - id: ShowerISR
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_showerISR
+                  job: pnn_TT01j2l_EFT_2018_showerISR
                   parameters: [nu_showerISR]
                 - id: ShowerFSR
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_showerFSR
+                  job: pnn_TT01j2l_EFT_2018_showerFSR
                   parameters: [nu_showerFSR]
                 - id: AlphaS
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_alphaS
+                  job: pnn_TT01j2l_EFT_2018_alphaS
                   parameters: [nu_alphaS]
                 - id: CMS_res_j_0
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_res_j_0_2016
+                  job: pnn_TT01j2l_EFT_2018_CMS_res_j_0_2018
                   parameters: [nu_CMS_res_j_0]
                 - id: CMS_res_j_1
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_res_j_1_2016
+                  job: pnn_TT01j2l_EFT_2018_CMS_res_j_1_2018
                   parameters: [nu_CMS_res_j_1]
                 - id: CMS_res_j_2
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_res_j_2_2016
+                  job: pnn_TT01j2l_EFT_2018_CMS_res_j_2_2018
                   parameters: [nu_CMS_res_j_2]
                 - id: CMS_res_j_3
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_res_j_3_2016
+                  job: pnn_TT01j2l_EFT_2018_CMS_res_j_3_2018
                   parameters: [nu_CMS_res_j_3]
                 - id: CMS_res_j_4
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_res_j_4_2016
+                  job: pnn_TT01j2l_EFT_2018_CMS_res_j_4_2018
                   parameters: [nu_CMS_res_j_4]
                 - id: CMS_res_j_5
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_res_j_5_2016
+                  job: pnn_TT01j2l_EFT_2018_CMS_res_j_5_2018
                   parameters: [nu_CMS_res_j_5]
                 - id: CMS_scale_j_FlavorPureBottom
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom
+                  job: pnn_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureBottom
                   parameters: [nu_CMS_scale_j_FlavorPureBottom]
                 - id: CMS_scale_j_FlavorPureCharm
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm
+                  job: pnn_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureCharm
                   parameters: [nu_CMS_scale_j_FlavorPureCharm]
                 - id: CMS_scale_j_FlavorPureGluon
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon
+                  job: pnn_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureGluon
                   parameters: [nu_CMS_scale_j_FlavorPureGluon]
                 - id: CMS_scale_j_FlavorPureQuark
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark
+                  job: pnn_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureQuark
                   parameters: [nu_CMS_scale_j_FlavorPureQuark]
-                - id: CMS_scale_j_Regrouped_Absolute_2016
+                - id: CMS_scale_j_Regrouped_Absolute_2018
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016
-                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
+                  job: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute_2018
+                  parameters: [nu_CMS_scale_j_Regrouped_Absolute_2018]
                 - id: CMS_scale_j_Regrouped_Absolute
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute
+                  job: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute
                   parameters: [nu_CMS_scale_j_Regrouped_Absolute]
-                - id: CMS_scale_j_Regrouped_BBEC1_2016
+                - id: CMS_scale_j_Regrouped_BBEC1_2018
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016
-                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
+                  job: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1_2018
+                  parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2018]
                 - id: CMS_scale_j_Regrouped_BBEC1
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1
+                  job: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1
                   parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
-                - id: CMS_scale_j_Regrouped_EC2_2016
+                - id: CMS_scale_j_Regrouped_EC2_2018
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016
-                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
+                  job: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2_2018
+                  parameters: [nu_CMS_scale_j_Regrouped_EC2_2018]
                 - id: CMS_scale_j_Regrouped_EC2
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2
+                  job: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2
                   parameters: [nu_CMS_scale_j_Regrouped_EC2]
-                - id: CMS_scale_j_Regrouped_HF_2016
+                - id: CMS_scale_j_Regrouped_HF_2018
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016
-                  parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
+                  job: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF_2018
+                  parameters: [nu_CMS_scale_j_Regrouped_HF_2018]
                 - id: CMS_scale_j_Regrouped_HF
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF
+                  job: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF
                   parameters: [nu_CMS_scale_j_Regrouped_HF]
                 - id: CMS_scale_j_Regrouped_RelativeBal
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal
+                  job: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeBal
                   parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
-                - id: CMS_scale_j_Regrouped_RelativeSample_2016
+                - id: CMS_scale_j_Regrouped_RelativeSample_2018
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016
-                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
+                  job: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeSample_2018
+                  parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2018]
                 - id: Uncl
                   type: pnn
-                  job: pnn_TT01j2l_EFT_2016_Uncl
+                  job: pnn_TT01j2l_EFT_2018_Uncl
                   parameters: [nu_Uncl]
 
 
 jobs:
 
-  - id: bit_TT01j2l_EFT_2016_ctG
+  - id: bit_TT01j2l_EFT_2018_ctG
     type: bit
-    region: SR_2016
-    process: TT01j2l_EFT_2016
+    region: SR_2018
+    process: TT01j2l_EFT_2018
     numba: True
     eft: 
         parameters: [ctGRe, ctGIm]
@@ -220,52 +220,52 @@ jobs:
     runtime:
       training_plots: true
     output:
-      filename: "bit_TT01j2l_EFT_2016_ctG.pkl"
+      filename: "bit_TT01j2l_EFT_2018_ctG.pkl"
 
-  - id: scaler_TT01j2l_EFT_2016
+  - id: scaler_TT01j2l_EFT_2018
     type: scaler
-    process: TT01j2l_EFT_2016
-    region: SR_2016
+    process: TT01j2l_EFT_2018
+    region: SR_2018
     selection: null
     output:
-      filename: "Scaler_TT01j2l_EFT_2016.pkl"
+      filename: "Scaler_TT01j2l_EFT_2018.pkl"
 
-  - id: icp_TT01j2l_EFT_2016_L1Prefire
+  - id: icp_TT01j2l_EFT_2018_L1Prefire
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_l1prefire]
     combinations: [[nu_l1prefire]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["L1PreFiringWeight_Nom"]
       addweights: ["L1PreFiringWeight_Dn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["L1PreFiringWeight_Nom"]
       addweights: ["L1PreFiringWeight_Up"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_L1Prefire.pkl
+      filename: icp_TT01j2l_EFT_2018_L1Prefire.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_L1Prefire
+  - id: pnn_TT01j2l_EFT_2018_L1Prefire
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_l1prefire]
     combinations: [[nu_l1prefire]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["L1PreFiringWeight_Nom"]
       addweights: ["L1PreFiringWeight_Dn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["L1PreFiringWeight_Nom"]
       addweights: ["L1PreFiringWeight_Up"]
     model:
@@ -282,45 +282,45 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_L1Prefire
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_L1Prefire
 
-  - id: icp_TT01j2l_EFT_2016_PU
+  - id: icp_TT01j2l_EFT_2018_PU
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_pu]
     combinations: [[nu_pu]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["Pileup_SF"]
       addweights: ["Pileup_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["Pileup_SF"]
       addweights: ["Pileup_SFUp"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_PU.pkl
+      filename: icp_TT01j2l_EFT_2018_PU.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_PU
+  - id: pnn_TT01j2l_EFT_2018_PU
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_pu]
     combinations: [[nu_pu]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["Pileup_SF"]
       addweights: ["Pileup_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["Pileup_SF"]
       addweights: ["Pileup_SFUp"]
     model:
@@ -337,45 +337,45 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_PU
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_PU
 
-  - id: icp_TT01j2l_EFT_2016_MuSF
+  - id: icp_TT01j2l_EFT_2018_MuSF
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_MuSF]
     combinations: [[nu_MuSF]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["lepMu_SF"]
       addweights: ["lepMu_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["lepMu_SF"]
       addweights: ["lepMu_SFUp"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_MuSF.pkl
+      filename: icp_TT01j2l_EFT_2018_MuSF.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_MuSF
+  - id: pnn_TT01j2l_EFT_2018_MuSF
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_MuSF]
     combinations: [[nu_MuSF]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["lepMu_SF"]
       addweights: ["lepMu_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["lepMu_SF"]
       addweights: ["lepMu_SFUp"]
     model:
@@ -392,45 +392,45 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_MuSF
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_MuSF
 
-  - id: icp_TT01j2l_EFT_2016_EleSF
+  - id: icp_TT01j2l_EFT_2018_EleSF
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_EleSF]
     combinations: [[nu_EleSF]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["lepEle_SF"]
       addweights: ["lepEle_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["lepEle_SF"]
       addweights: ["lepEle_SFUp"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_EleSF.pkl
+      filename: icp_TT01j2l_EFT_2018_EleSF.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_EleSF
+  - id: pnn_TT01j2l_EFT_2018_EleSF
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_EleSF]
     combinations: [[nu_EleSF]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["lepEle_SF"]
       addweights: ["lepEle_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["lepEle_SF"]
       addweights: ["lepEle_SFUp"]
     model:
@@ -447,45 +447,45 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_EleSF
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_EleSF
 
-  - id: icp_TT01j2l_EFT_2016_BTag_b
+  - id: icp_TT01j2l_EFT_2018_BTag_b
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_btag_b]
     combinations: [[nu_btag_b]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_BTag_b.pkl
+      filename: icp_TT01j2l_EFT_2018_BTag_b.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_BTag_b
+  - id: pnn_TT01j2l_EFT_2018_BTag_b
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_btag_b]
     combinations: [[nu_btag_b]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_correlated_heavy_SFUp"]
     model:
@@ -502,44 +502,44 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_BTag_b
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_BTag_b
 
-  - id: icp_TT01j2l_EFT_2016_BTag_l
+  - id: icp_TT01j2l_EFT_2018_BTag_l
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_btag_l]
     combinations: [[nu_btag_l]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_BTag_l.pkl
-  - id: pnn_TT01j2l_EFT_2016_BTag_l
+      filename: icp_TT01j2l_EFT_2018_BTag_l.pkl
+  - id: pnn_TT01j2l_EFT_2018_BTag_l
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_btag_l]
     combinations: [[nu_btag_l]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFDn"]
     - coords: [0.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       removeweights: ["btagSF_fixedWP_SF"]
       addweights: ["btagSF_fixedWP_SF__CMS_eff_b_light_SFUp"]
     model:
@@ -556,82 +556,82 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_BTag_l
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_BTag_l
 
-  - id: icp_TT01j2l_EFT_2016_scales
+  - id: icp_TT01j2l_EFT_2018_scales
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_mu_ren, nu_mu_fac]
     combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
           nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
     base_points:
     - coords: [-1.0, -1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren0p5_fac0p5"]
     - coords: [-1.0, 0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren0p5_fac1p0"]
     - coords: [-1.0, 1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren0p5_fac2p0"]
     - coords: [0, -1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren1p0_fac0p5"]
     - coords: [0, 0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren1p0_fac1p0"]
       nominal: true
     - coords: [0, 1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren1p0_fac2p0"]
     - coords: [1.0, -1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren2p0_fac0p5"]
     - coords: [1.0, 0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren2p0_fac1p0"]
     - coords: [1.0, 1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren2p0_fac2p0"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_scales.pkl
+      filename: icp_TT01j2l_EFT_2018_scales.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_scales
+  - id: pnn_TT01j2l_EFT_2018_scales
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_mu_ren, nu_mu_fac]
     combinations: [[nu_mu_ren], [nu_mu_fac], [nu_mu_ren, nu_mu_ren], [nu_mu_ren, 
           nu_mu_fac], [nu_mu_fac, nu_mu_fac]]
     base_points:
     - coords: [-1.0, -1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren0p5_fac0p5"]
     - coords: [-1.0, 0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren0p5_fac1p0"]
     - coords: [-1.0, 1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren0p5_fac2p0"]
     - coords: [0, -1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren1p0_fac0p5"]
     - coords: [0, 0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren1p0_fac1p0"]
       nominal: true
     - coords: [0, 1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren1p0_fac2p0"]
     - coords: [1.0, -1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren2p0_fac0p5"]
     - coords: [1.0, 0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren2p0_fac1p0"]
     - coords: [1.0, 1.0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       addweights: ["scale_ren2p0_fac2p0"]
     model:
       hidden_layers:
@@ -647,42 +647,42 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_scales
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_scales
 
-  - id: icp_TT01j2l_EFT_2016_showerISR
+  - id: icp_TT01j2l_EFT_2018_showerISR
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_showerISR]
     combinations: [[nu_showerISR]]
     base_points:
       - coords: [-1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         addweights: ["shower_isr0p5_fsr1p0"]
       - coords: [0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         nominal: true
       - coords: [1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         addweights: ["shower_isr2p0_fsr1p0"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_showerISR.pkl
+      filename: icp_TT01j2l_EFT_2018_showerISR.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_showerISR
+  - id: pnn_TT01j2l_EFT_2018_showerISR
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_showerISR]
     combinations: [[nu_showerISR]]
     base_points:
       - coords: [-1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         addweights: ["shower_isr0p5_fsr1p0"]
       - coords: [0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         nominal: true
       - coords: [1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         addweights: ["shower_isr2p0_fsr1p0"]
     model:
       hidden_layers:
@@ -698,42 +698,42 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_showerISR
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_showerISR
 
-  - id: icp_TT01j2l_EFT_2016_showerFSR
+  - id: icp_TT01j2l_EFT_2018_showerFSR
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_showerFSR]
     combinations: [[nu_showerFSR]]
     base_points:
       - coords: [-1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         addweights: ["shower_isr1p0_fsr0p5"]
       - coords: [0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         nominal: true
       - coords: [1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         addweights: ["shower_isr1p0_fsr2p0"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_showerFSR.pkl
+      filename: icp_TT01j2l_EFT_2018_showerFSR.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_showerFSR
+  - id: pnn_TT01j2l_EFT_2018_showerFSR
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_showerFSR]
     combinations: [[nu_showerFSR]]
     base_points:
       - coords: [-1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         addweights: ["shower_isr1p0_fsr0p5"]
       - coords: [0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         nominal: true
       - coords: [1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         addweights: ["shower_isr1p0_fsr2p0"]
     model:
       hidden_layers:
@@ -749,42 +749,42 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_showerFSR
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_showerFSR
 
-  - id: icp_TT01j2l_EFT_2016_alphaS
+  - id: icp_TT01j2l_EFT_2018_alphaS
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_alphaS]
     combinations: [[nu_alphaS]]
     base_points:
       - coords: [-1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         addweights: ["pdf_alphas_dn"]
       - coords: [0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         nominal: true
       - coords: [1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         addweights: ["pdf_alphas_up"]
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_alphaS.pkl
+      filename: icp_TT01j2l_EFT_2018_alphaS.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_alphaS
+  - id: pnn_TT01j2l_EFT_2018_alphaS
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_alphaS]
     combinations: [[nu_alphaS]]
     base_points:
       - coords: [-1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         addweights: ["pdf_alphas_dn"]
       - coords: [0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         nominal: true
       - coords: [1.0]
-        loader: TT01j2l_EFT_2016
+        loader: TT01j2l_EFT_2018
         addweights: ["pdf_alphas_up"]
     model:
       hidden_layers:
@@ -800,39 +800,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_alphaS
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_alphaS
 
-  - id: icp_TT01j2l_EFT_2016_CMS_res_j_0_2016
+  - id: icp_TT01j2l_EFT_2018_CMS_res_j_0_2018
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_res_j_0]
     combinations: [[nu_CMS_res_j_0]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_0_2016_down
+      loader: TT01j2l_EFT_2018_CMS_res_j_0_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_0_2016_up
+      loader: TT01j2l_EFT_2018_CMS_res_j_0_2018_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_res_j_0_2016.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_res_j_0_2018.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_res_j_0_2016
+  - id: pnn_TT01j2l_EFT_2018_CMS_res_j_0_2018
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_res_j_0]
     combinations: [[nu_CMS_res_j_0]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_0_2016_down
+      loader: TT01j2l_EFT_2018_CMS_res_j_0_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_0_2016_up
+      loader: TT01j2l_EFT_2018_CMS_res_j_0_2018_up
     model:
       hidden_layers:
       - 128
@@ -847,39 +847,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_res_j_0_2016
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_res_j_0_2018
 
-  - id: icp_TT01j2l_EFT_2016_CMS_res_j_1_2016
+  - id: icp_TT01j2l_EFT_2018_CMS_res_j_1_2018
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_res_j_1]
     combinations: [[nu_CMS_res_j_1]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_1_2016_down
+      loader: TT01j2l_EFT_2018_CMS_res_j_1_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_1_2016_up
+      loader: TT01j2l_EFT_2018_CMS_res_j_1_2018_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_res_j_1_2016.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_res_j_1_2018.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_res_j_1_2016
+  - id: pnn_TT01j2l_EFT_2018_CMS_res_j_1_2018
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_res_j_1]
     combinations: [[nu_CMS_res_j_1]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_1_2016_down
+      loader: TT01j2l_EFT_2018_CMS_res_j_1_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_1_2016_up
+      loader: TT01j2l_EFT_2018_CMS_res_j_1_2018_up
     model:
       hidden_layers:
       - 128
@@ -894,39 +894,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_res_j_1_2016
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_res_j_1_2018
 
-  - id: icp_TT01j2l_EFT_2016_CMS_res_j_2_2016
+  - id: icp_TT01j2l_EFT_2018_CMS_res_j_2_2018
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_res_j_2]
     combinations: [[nu_CMS_res_j_2]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_2_2016_down
+      loader: TT01j2l_EFT_2018_CMS_res_j_2_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_2_2016_up
+      loader: TT01j2l_EFT_2018_CMS_res_j_2_2018_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_res_j_2_2016.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_res_j_2_2018.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_res_j_2_2016
+  - id: pnn_TT01j2l_EFT_2018_CMS_res_j_2_2018
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_res_j_2]
     combinations: [[nu_CMS_res_j_2]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_2_2016_down
+      loader: TT01j2l_EFT_2018_CMS_res_j_2_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_2_2016_up
+      loader: TT01j2l_EFT_2018_CMS_res_j_2_2018_up
     model:
       hidden_layers:
       - 128
@@ -941,39 +941,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_res_j_2_2016
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_res_j_2_2018
 
-  - id: icp_TT01j2l_EFT_2016_CMS_res_j_3_2016
+  - id: icp_TT01j2l_EFT_2018_CMS_res_j_3_2018
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_res_j_3]
     combinations: [[nu_CMS_res_j_3]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_3_2016_down
+      loader: TT01j2l_EFT_2018_CMS_res_j_3_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_3_2016_up
+      loader: TT01j2l_EFT_2018_CMS_res_j_3_2018_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_res_j_3_2016.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_res_j_3_2018.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_res_j_3_2016
+  - id: pnn_TT01j2l_EFT_2018_CMS_res_j_3_2018
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_res_j_3]
     combinations: [[nu_CMS_res_j_3]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_3_2016_down
+      loader: TT01j2l_EFT_2018_CMS_res_j_3_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_3_2016_up
+      loader: TT01j2l_EFT_2018_CMS_res_j_3_2018_up
     model:
       hidden_layers:
       - 128
@@ -988,39 +988,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_res_j_3_2016
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_res_j_3_2018
 
-  - id: icp_TT01j2l_EFT_2016_CMS_res_j_4_2016
+  - id: icp_TT01j2l_EFT_2018_CMS_res_j_4_2018
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_res_j_4]
     combinations: [[nu_CMS_res_j_4]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_4_2016_down
+      loader: TT01j2l_EFT_2018_CMS_res_j_4_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_4_2016_up
+      loader: TT01j2l_EFT_2018_CMS_res_j_4_2018_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_res_j_4_2016.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_res_j_4_2018.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_res_j_4_2016
+  - id: pnn_TT01j2l_EFT_2018_CMS_res_j_4_2018
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_res_j_4]
     combinations: [[nu_CMS_res_j_4]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_4_2016_down
+      loader: TT01j2l_EFT_2018_CMS_res_j_4_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_4_2016_up
+      loader: TT01j2l_EFT_2018_CMS_res_j_4_2018_up
     model:
       hidden_layers:
       - 128
@@ -1035,39 +1035,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_res_j_4_2016
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_res_j_4_2018
 
-  - id: icp_TT01j2l_EFT_2016_CMS_res_j_5_2016
+  - id: icp_TT01j2l_EFT_2018_CMS_res_j_5_2018
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_res_j_5]
     combinations: [[nu_CMS_res_j_5]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_5_2016_down
+      loader: TT01j2l_EFT_2018_CMS_res_j_5_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_5_2016_up
+      loader: TT01j2l_EFT_2018_CMS_res_j_5_2018_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_res_j_5_2016.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_res_j_5_2018.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_res_j_5_2016
+  - id: pnn_TT01j2l_EFT_2018_CMS_res_j_5_2018
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_res_j_5]
     combinations: [[nu_CMS_res_j_5]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_5_2016_down
+      loader: TT01j2l_EFT_2018_CMS_res_j_5_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_res_j_5_2016_up
+      loader: TT01j2l_EFT_2018_CMS_res_j_5_2018_up
     model:
       hidden_layers:
       - 128
@@ -1082,40 +1082,40 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_res_j_5_2016
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_res_j_5_2018
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom
+  - id: icp_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureBottom
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_FlavorPureBottom]
     combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureBottom_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureBottom_up
   
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureBottom.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom
+  - id: pnn_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureBottom
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_FlavorPureBottom]
     combinations: [[nu_CMS_scale_j_FlavorPureBottom]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureBottom_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureBottom_up
   
     model:
       hidden_layers:
@@ -1131,39 +1131,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureBottom
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureBottom
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm
+  - id: icp_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureCharm
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_FlavorPureCharm]
     combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureCharm_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureCharm_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureCharm.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm
+  - id: pnn_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureCharm
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_FlavorPureCharm]
     combinations: [[nu_CMS_scale_j_FlavorPureCharm]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureCharm_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureCharm_up
     model:
       hidden_layers:
       - 128
@@ -1178,39 +1178,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureCharm
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureCharm
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon
+  - id: icp_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureGluon
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_FlavorPureGluon]
     combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureGluon_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureGluon_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureGluon.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon
+  - id: pnn_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureGluon
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_FlavorPureGluon]
     combinations: [[nu_CMS_scale_j_FlavorPureGluon]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureGluon_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureGluon_up
     model:
       hidden_layers:
       - 128
@@ -1225,39 +1225,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureGluon
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureGluon
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark
+  - id: icp_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureQuark
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_FlavorPureQuark]
     combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureQuark_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureQuark_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureQuark.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark
+  - id: pnn_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureQuark
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_FlavorPureQuark]
     combinations: [[nu_CMS_scale_j_FlavorPureQuark]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureQuark_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_FlavorPureQuark_up
     model:
       hidden_layers:
       - 128
@@ -1272,39 +1272,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_FlavorPureQuark
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_scale_j_FlavorPureQuark
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute_2018
     type: icp
-    region: SR_2016
-    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2018]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute_2018_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute_2018.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016
+  - id: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute_2018
     type: pnn
-    region: SR_2016
-    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2016]]
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_Absolute_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_Absolute_2018]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute_2018_up
     model:
       hidden_layers:
       - 128
@@ -1319,40 +1319,40 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_2016
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute_2018
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute
+  - id: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_Regrouped_Absolute]
     combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute_up
   
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute
+  - id: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_Regrouped_Absolute]
     combinations: [[nu_CMS_scale_j_Regrouped_Absolute]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute_up
   
     model:
       hidden_layers:
@@ -1368,39 +1368,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_Absolute
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_Absolute
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1_2018
     type: icp
-    region: SR_2016
-    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2018]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1_2018_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1_2018.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016
+  - id: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1_2018
     type: pnn
-    region: SR_2016
-    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2016]]
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_BBEC1_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_BBEC1_2018]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1_2018_up
     model:
       hidden_layers:
       - 128
@@ -1415,39 +1415,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_2016
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1_2018
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
     combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1
+  - id: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_Regrouped_BBEC1]
     combinations: [[nu_CMS_scale_j_Regrouped_BBEC1]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1_up
     model:
       hidden_layers:
       - 128
@@ -1462,39 +1462,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_BBEC1
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_BBEC1
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2_2018
     type: icp
-    region: SR_2016
-    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2018]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2_2018_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2_2018.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016
+  - id: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2_2018
     type: pnn
-    region: SR_2016
-    parameters: [nu_CMS_scale_j_Regrouped_EC2_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2016]]
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_EC2_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_EC2_2018]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2_2018_up
     model:
       hidden_layers:
       - 128
@@ -1509,39 +1509,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_2016
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2_2018
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2
+  - id: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_Regrouped_EC2]
     combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2
+  - id: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_Regrouped_EC2]
     combinations: [[nu_CMS_scale_j_Regrouped_EC2]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2_up
     model:
       hidden_layers:
       - 128
@@ -1556,39 +1556,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_EC2
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_EC2
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF_2018
     type: icp
-    region: SR_2016
-    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2018]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF_2018_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF_2018.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016
+  - id: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF_2018
     type: pnn
-    region: SR_2016
-    parameters: [nu_CMS_scale_j_Regrouped_HF_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_HF_2016]]
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_HF_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_HF_2018]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF_2018_up
     model:
       hidden_layers:
       - 128
@@ -1603,39 +1603,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_2016
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF_2018
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF
+  - id: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_Regrouped_HF]
     combinations: [[nu_CMS_scale_j_Regrouped_HF]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF
+  - id: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_Regrouped_HF]
     combinations: [[nu_CMS_scale_j_Regrouped_HF]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF_up
     model:
       hidden_layers:
       - 128
@@ -1650,39 +1650,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_HF
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_HF
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeBal
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
     combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeBal_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeBal_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeBal.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal
+  - id: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeBal
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_CMS_scale_j_Regrouped_RelativeBal]
     combinations: [[nu_CMS_scale_j_Regrouped_RelativeBal]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeBal_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeBal_up
     model:
       hidden_layers:
       - 128
@@ -1697,39 +1697,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeBal
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeBal
 
-  - id: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeSample_2018
     type: icp
-    region: SR_2016
-    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2018]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeSample_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeSample_2018_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016.pkl
+      filename: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeSample_2018.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+  - id: pnn_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeSample_2018
     type: pnn
-    region: SR_2016
-    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2016]
-    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2016]]
+    region: SR_2018
+    parameters: [nu_CMS_scale_j_Regrouped_RelativeSample_2018]
+    combinations: [[nu_CMS_scale_j_Regrouped_RelativeSample_2018]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016_down
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeSample_2018_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016_up
+      loader: TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeSample_2018_up
     model:
       hidden_layers:
       - 128
@@ -1744,39 +1744,39 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_CMS_scale_j_Regrouped_RelativeSample_2016
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_CMS_scale_j_Regrouped_RelativeSample_2018
       
-  - id: icp_TT01j2l_EFT_2016_Uncl
+  - id: icp_TT01j2l_EFT_2018_Uncl
     type: icp
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_Uncl]
     combinations: [[nu_Uncl]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_Uncl_down
+      loader: TT01j2l_EFT_2018_Uncl_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_Uncl_up
+      loader: TT01j2l_EFT_2018_Uncl_up
     train_ratio: true
     output:
-      filename: icp_TT01j2l_EFT_2016_Uncl.pkl
+      filename: icp_TT01j2l_EFT_2018_Uncl.pkl
 
-  - id: pnn_TT01j2l_EFT_2016_Uncl
+  - id: pnn_TT01j2l_EFT_2018_Uncl
     type: pnn
-    region: SR_2016
+    region: SR_2018
     parameters: [nu_Uncl]
     combinations: [[nu_Uncl]]
     base_points:
     - coords: [-1.0]
-      loader: TT01j2l_EFT_2016_Uncl_down
+      loader: TT01j2l_EFT_2018_Uncl_down
     - coords: [0]
-      loader: TT01j2l_EFT_2016
+      loader: TT01j2l_EFT_2018
       nominal: true
     - coords: [1.0]
-      loader: TT01j2l_EFT_2016_Uncl_up
+      loader: TT01j2l_EFT_2018_Uncl_up
     model:
       hidden_layers:
       - 128
@@ -1791,5 +1791,5 @@ jobs:
       n_split: 3
       rebin: 2
     extras:
-      use_scaler: scaler_TT01j2l_EFT_2016
-      use_icp: icp_TT01j2l_EFT_2016_Uncl
+      use_scaler: scaler_TT01j2l_EFT_2018
+      use_icp: icp_TT01j2l_EFT_2018_Uncl

--- a/data/RDataLoader.py
+++ b/data/RDataLoader.py
@@ -633,6 +633,7 @@ class RDataLoader:
             feature_names=self.feature_names,
             observer_names=self.observer_names,
             weight_branches=self.weight_branches if weight_branches is None else weight_branches,
+            weight_rescale=self.weight_rescale,
         )
 
     def clone(self) -> "RDataLoader":

--- a/data/samples_eft.py
+++ b/data/samples_eft.py
@@ -16,10 +16,17 @@ import logging
 logger = logging.getLogger(__name__)
 
 # used in EFT sample factory class
+import data.samples_RunII as samples_RunII
 from data.samples_RunII import Factory as Factory_RunII
 from data.samples_RunII import BASE_DIRECTORY as BASE_DIRECTORY_RUNII
+from data.samples_RunII import _parse_name
+from systematics_RunII import SYSTEMATICS
 
 BASE_DIRECTORY_EFT = "/groups/hephy/cms/ricardo.barrue/CMGRDF_ntuples_ttbar_EFT/v3-2_nJ2p_nB2p_2l"
+
+ERA_LABELS = {"2016APV": "UL16APV", "2016": "UL16", "2018": "UL18"}
+MTT_SLICES = ["mtt_0to700", "mtt_700to900", "mtt_900toInf"]
+RUNII_ERAS = ["2016APV", "2016", "2018"]
 
 # no longer needed since lumi normalization is done at cmgrdf level
 # LUMI = {
@@ -107,87 +114,132 @@ def _eft_loader(*relpaths: str) -> RDataLoader:
     # selection to truncate outliers (see samples_eft_gen) can be added in the config
     return loader
 
-# configs
-TT01j2l_EFT_2016APV_mtt_0to700 = _eft_loader(
-    "2016APV/TT01j2l_UL16APV_mtt_0to700_nominal.root",
-)
-TT01j2l_EFT_2016APV_mtt_700to900 = _eft_loader(
-    "2016APV/TT01j2l_UL16APV_mtt_700to900_nominal.root",
-)
-TT01j2l_EFT_2016APV_mtt_900toInf = _eft_loader(
-    "2016APV/TT01j2l_UL16APV_mtt_900toInf_nominal.root",
-)
-
-TT01j2l_EFT_2016_mtt_0to700 = _eft_loader(
-    "2016/TT01j2l_UL16_mtt_0to700_nominal.root",
-)
-TT01j2l_EFT_2016_mtt_700to900 = _eft_loader(
-    "2016/TT01j2l_UL16_mtt_700to900_nominal.root",
-)
-TT01j2l_EFT_2016_mtt_900toInf = _eft_loader(
-    "2016/TT01j2l_UL16_mtt_900toInf_nominal.root",
-)
+# ----------------------------------------------------------------------
+# Base sample (nominal) and lazy variation builders
+# ----------------------------------------------------------------------
+_base_eft = None
 
 
-# 2017 files cannot be generated atm, as they're
-# missing some of the branches to make jet corrections
-# TT01j2l_EFT_2017_mtt_0to700 = _eft_loader(
-#     "2017/TT01j2l_UL17_mtt_0to700_nominal.root",
-# )
-# TT01j2l_EFT_2017_mtt_700to900 = _eft_loader(
-#     "2017/TT01j2l_UL17_mtt_700to900_nominal.root",
-# )
-# TT01j2l_EFT_2017_mtt_900toInf = _eft_loader(
-#     "2017/TT01j2l_UL17_mtt_900toInf_nominal.root",
-# )
-
-TT01j2l_EFT_2018_mtt_0to700 = _eft_loader(
-    "2018/TT01j2l_UL18_mtt_0to700_nominal.root",
-)
-TT01j2l_EFT_2018_mtt_700to900 = _eft_loader(
-    "2018/TT01j2l_UL18_mtt_700to900_nominal.root",
-)
-TT01j2l_EFT_2018_mtt_900toInf = _eft_loader(
-    "2018/TT01j2l_UL18_mtt_900toInf_nominal.root",
-)
+def _get_base() -> RDataLoader:
+    """Return the single nominal EFT loader that every variation clones from."""
+    global _base_eft
+    if _base_eft is None:
+        _base_eft = _eft_loader("2016/TT01j2l_UL16_mtt_0to700_nominal.root")
+    return _base_eft
 
 
-TT01j2l_EFT_2016APV = _eft_loader(
-    "2016APV/TT01j2l_UL16APV_mtt_0to700_nominal.root",
-    "2016APV/TT01j2l_UL16APV_mtt_700to900_nominal.root",
-    "2016APV/TT01j2l_UL16APV_mtt_900toInf_nominal.root",
-)
-TT01j2l_EFT_2016 = _eft_loader(
-    "2016/TT01j2l_UL16_mtt_0to700_nominal.root",
-    "2016/TT01j2l_UL16_mtt_700to900_nominal.root",
-    "2016/TT01j2l_UL16_mtt_900toInf_nominal.root",
-)
-# TT01j2l_EFT_2017 = _eft_loader(
-#     "2017/TT01j2l_UL17_mtt_0to700_nominal.root",
-#     "2017/TT01j2l_UL17_mtt_700to900_nominal.root",
-#     "2017/TT01j2l_UL17_mtt_900toInf_nominal.root",
-# )
+def _split_slice(tag: str) -> tuple[List[str], str]:
+    """
+    Split a tag into the mtt slice(s) it selects and the remaining tag.
 
-TT01j2l_EFT_2018 = _eft_loader(
-    "2018/TT01j2l_UL18_mtt_0to700_nominal.root",
-    "2018/TT01j2l_UL18_mtt_700to900_nominal.root",
-    "2018/TT01j2l_UL18_mtt_900toInf_nominal.root",
-)
+    - tag is exactly a slice (e.g. 'mtt_0to700')      -> that slice,  tag 'nominal'
+    - tag starts with '<slice>_' (e.g. 'mtt_0to700_Uncl_up') -> that slice, remainder
+    - otherwise (e.g. 'nominal', 'Uncl_up')           -> all three slices, tag unchanged
+    """
+    if tag in MTT_SLICES:
+        return [tag], "nominal"
+    for mtt_slice in MTT_SLICES:
+        prefix = f"{mtt_slice}_"
+        if tag.startswith(prefix):
+            return [mtt_slice], tag[len(prefix):]
+    return list(MTT_SLICES), tag
 
-TT01j2l_EFT_RunII = _eft_loader(
-    "2016APV/TT01j2l_UL16APV_mtt_0to700_nominal.root",
-    "2016APV/TT01j2l_UL16APV_mtt_700to900_nominal.root",
-    "2016APV/TT01j2l_UL16APV_mtt_900toInf_nominal.root",
-    "2016/TT01j2l_UL16_mtt_0to700_nominal.root",
-    "2016/TT01j2l_UL16_mtt_700to900_nominal.root",
-    "2016/TT01j2l_UL16_mtt_900toInf_nominal.root",
-    # "2017/TT01j2l_UL17_mtt_0to700_nominal.root",
-    # "2017/TT01j2l_UL17_mtt_700to900_nominal.root",
-    # "2017/TT01j2l_UL17_mtt_900toInf_nominal.root",
-    "2018/TT01j2l_UL18_mtt_0to700_nominal.root",
-    "2018/TT01j2l_UL18_mtt_700to900_nominal.root",
-    "2018/TT01j2l_UL18_mtt_900toInf_nominal.root",
-)
+
+def _make_variation(era: str, tag: str) -> RDataLoader:
+    """
+    Construct a TT01j2l_EFT variation from an era and tag, e.g.
+
+        era = "2016", tag = "CMS_res_j_0_2016_up"
+
+    Path(s) on disk:
+        <BASE_DIRECTORY_EFT>/<era>/TT01j2l_<ERA_LABELS[era]>_<slice>_<tag>.root
+
+    for each era (expanded from "RunII") and each mtt slice selected by `tag`.
+    The new loader is cloned from the baseline sample `_get_base()`.
+    """
+    eras = RUNII_ERAS if era == "RunII" else [era]
+    slices, file_tag = _split_slice(tag)
+
+    files = []
+    missing = []
+    for one_era in eras:
+        era_dir = os.path.join(BASE_DIRECTORY_EFT, one_era)
+        if not os.path.isdir(era_dir) or one_era not in ERA_LABELS:
+            missing.append(f"{era_dir} (era directory not available for EFT samples)")
+            continue
+        for mtt_slice in slices:
+            rootfile = os.path.join(
+                era_dir, f"TT01j2l_{ERA_LABELS[one_era]}_{mtt_slice}_{file_tag}.root"
+            )
+            if os.path.isfile(rootfile):
+                files.append(rootfile)
+            else:
+                missing.append(rootfile)
+
+    if missing:
+        raise FileNotFoundError(
+            "Missing EFT ROOT file(s) for era=" + repr(era) + ", tag=" + repr(tag) + ":\n"
+            + "\n".join(f"  - {m}" for m in missing)
+        )
+
+    return _get_base().clone_from_files(files)
+
+
+def __getattr__(name: str):
+    """
+    Lazily construct TT01j2l_EFT RDataLoaders on first access.
+
+    Supported patterns (see _parse_name / _split_slice):
+
+      - TT01j2l_EFT_<era>                       -> tag 'nominal', all mtt slices
+      - TT01j2l_EFT_<era>_<mtt slice>            -> tag 'nominal', one mtt slice
+      - TT01j2l_EFT_<era>_<mtt slice>_<tag>      -> one mtt slice
+      - TT01j2l_EFT_<era>_<tag>                  -> all mtt slices
+
+    <era> may be "RunII" (expands to 2016APV, 2016, 2018).
+
+    Any other process name is delegated to data.samples_RunII, which mirrors
+    the fallback the EFT Factory already performs.
+    """
+    if name.startswith("__") and name.endswith("__"):
+        raise AttributeError(name)
+
+    try:
+        process, era, tag = _parse_name(name)
+    except ValueError as e:
+        raise ImportError(str(e)) from None
+
+    if not tag:
+        tag = "nominal"
+
+    if process != "TT01j2l_EFT":
+        try:
+            loader = getattr(samples_RunII, name)
+        except Exception as e:
+            raise type(e)(
+                f"data.samples_eft does not recognise process {process!r}; delegated "
+                f"lookup of {name!r} to data.samples_RunII, which raised: {e}"
+            ) from e
+        globals()[name] = loader
+        return loader
+
+    try:
+        loader = _make_variation(era, tag)
+    except FileNotFoundError as e:
+        era_dir = Path(BASE_DIRECTORY_EFT) / era
+        prefix = f"TT01j2l_{ERA_LABELS[era]}_" if era in ERA_LABELS else None
+        available = (
+            sorted(f.stem[len(prefix):] for f in era_dir.glob("*.root"))
+            if prefix and era_dir.is_dir() else []
+        )
+        raise ImportError(
+            f"Could not construct EFT sample {name!r} (era={era!r}, tag={tag!r}).\n{e}\n"
+            f"Tags present on disk for era={era!r}: {', '.join(available) if available else '(none)'}\n"
+            f"Known systematic tags for era={era!r}: {', '.join(sorted(SYSTEMATICS.get(era, [])))}"
+        ) from None
+
+    globals()[name] = loader
+    return loader
 
 # Factory class to allow running fits with EFT samples (closure studies) and mixing EFT samples with Run 2 samples
 class Factory:
@@ -214,23 +266,23 @@ class Factory:
     
     def get(self, process: str, era: Optional[str] = None, tag: Optional[str] = None) -> RDataLoader:
 
-        loader = None
         if era is None and tag is None:
             try:
-                loader = globals()[process]
-                if self.features:
-                    loader.setFeatures( self.features )
-                if self.selection:
-                    loader.addSelection( self.selection, required_branches = self.selection_features )
-                return loader             
-            except KeyError:
+                loader = getattr(sys.modules[__name__], process)
+            except (AttributeError, ImportError):
                 logger.debug(f"EFT loader with name {process} not found! Reverting to Run 2 sample module.")
                 loader = self.Factory_RunII.get(process)
-                return loader
+        elif process == "TT01j2l_EFT":
+            loader = _make_variation(era, tag if tag else "nominal")
         else:
-            logger.debug("Asking for era and tag, only available for Run 2 sample module.")
+            logger.debug("era/tag given for a non-EFT process, forwarding to Run 2 sample module.")
             loader = self.Factory_RunII.get(process, era, tag)
-            return loader
+
+        if self.features:
+            loader.setFeatures( self.features )
+        if self.selection:
+            loader.addSelection( self.selection, required_branches = self.selection_features )
+        return loader
 
 
 if __name__ == "__main__":
@@ -238,7 +290,7 @@ if __name__ == "__main__":
     # lower triangular matrix of derivatives
     print(eft_derivatives)
 
-    base_loader = TT01j2l_EFT_2016_mtt_0to700
+    base_loader = _get_base()
     print("Base:_nominal.root", base_loader)
     F, O, W = base_loader.materialize(0, "fow")
     print("Shapes:_nominal.root", F.shape, O.shape, W.shape)
@@ -259,3 +311,9 @@ if __name__ == "__main__":
     print(L_from_samples_RunII)
     print("Shapes:L_from_samples_RunII.root", F.shape, O.shape, W.shape)
     print("w[:5]",W[:5])
+
+    # Real check that the systematic EFT files carry the derivative branches:
+    # _eft_loader sets strict_branches=True, so a missing der_* branch crashes here.
+    L_syst = getattr(sys.modules[__name__], "TT01j2l_EFT_2016_Uncl_up")
+    F, O, W = L_syst.materialize(0, "fow")
+    print("Shapes:TT01j2l_EFT_2016_Uncl_up", F.shape, O.shape, W.shape)


### PR DESCRIPTION
Code and configs for training systematics on EFT samples.

Wanted to keep the EFT sample loader as separate as possible from the standard (Run 2) sample loader. This implied porting and slightly modifying the functionality in the former.